### PR TITLE
Add security scan and policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,5 @@ jobs:
       - run: npm run test:coverage
       - name: Report Vitest Coverage
         uses: davelosert/vitest-coverage-report-action@v2
+      - name: Security Scan
+        run: npm run security-check

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 [![Version](https://img.shields.io/badge/version-2.1-blue)](https://github.com/PV-Bhat/vibe-check-mcp-server)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+[![CI](https://github.com/PV-Bhat/vibe-check-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/PV-Bhat/vibe-check-mcp-server/actions/workflows/ci.yml)
 [![smithery badge](https://smithery.ai/badge/@PV-Bhat/vibe-check-mcp-server)](https://smithery.ai/server/@PV-Bhat/vibe-check-mcp-server)
 [![Verified on MseeP](https://mseep.ai/badge.svg)](https://mseep.ai/app/a2954e62-a3f8-45b8-9a03-33add8b92599)
 
@@ -160,6 +161,12 @@ As an autonomous agent you will:
 - [Philosophy](./docs/philosophy.md)
 - [Case Studies](./docs/case-studies.md)
 - [Changelog](./docs/changelog.md)
+
+## Security
+
+This repository includes a CI-based security scan that runs on every pull request.
+It checks dependencies with `npm audit` and scans the source for risky patterns.
+See [SECURITY.md](./SECURITY.md) for details and how to report issues.
 
 ## To-do List
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+VibeCheck MCP is designed as a lightweight oversight layer for AI coding agents. While it does not execute code on behalf of the agent, it processes user prompts and sends them to third‑party LLM APIs. This document outlines our approach to keeping that process secure.
+
+## Supported Versions
+Only the latest release receives security updates. Please upgrade regularly to stay protected.
+
+## Threat Model
+- **Prompt injection**: malicious text could attempt to alter the meta-mentor instructions. VibeCheck uses a fixed system prompt and validates required fields to mitigate this.
+- **Tool misuse**: the server exposes only two safe tools (`vibe_check` and `vibe_learn`). No command execution or file access is performed.
+- **Data leakage**: requests are forwarded to the configured LLM provider. Avoid sending sensitive data if using hosted APIs. The optional `vibe_learn` log can be disabled via environment variables.
+- **Impersonation**: run VibeCheck only from this official repository or the published npm package. Verify the source before deployment.
+
+## Reporting a Vulnerability
+If you discover a security issue, please open a private GitHub issue or email the maintainer listed in `package.json`. We will acknowledge your report within 48 hours and aim to provide a fix promptly.
+
+## Continuous Security
+A custom security scan runs in CI on every pull request. It checks dependencies for known vulnerabilities and searches the source tree for dangerous patterns. The workflow fails if any issue is detected.
+

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "start": "node build/index.js",
     "dev": "tsc-watch --onSuccess \"node build/index.js\"",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "security-check": "node scripts/security-check.cjs"
   },
   "dependencies": {
     "@google/generative-ai": "^0.17.1",

--- a/scripts/security-check.cjs
+++ b/scripts/security-check.cjs
@@ -1,0 +1,59 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function runAudit() {
+  try {
+    const output = execSync('npm audit --production --json', { encoding: 'utf8' });
+    const json = JSON.parse(output);
+    const vulnerabilities = json.vulnerabilities || {};
+    let highOrCritical = 0;
+    for (const name of Object.keys(vulnerabilities)) {
+      const v = vulnerabilities[name];
+      if (['high', 'critical'].includes(v.severity)) {
+        console.error(`High severity issue in dependency: ${name}`);
+        highOrCritical++;
+      }
+    }
+    if (highOrCritical > 0) {
+      console.error(`Found ${highOrCritical} high or critical vulnerabilities`);
+      process.exitCode = 1;
+    } else {
+      console.log('Dependency audit clean');
+    }
+  } catch (err) {
+    console.error('npm audit failed', err.message);
+    process.exitCode = 1;
+  }
+}
+
+function scanSource() {
+  const suspiciousPatterns = [/eval\s*\(/, /child_process/, /exec\s*\(/, /spawn\s*\(/];
+  let flagged = false;
+  function scanDir(dir) {
+    for (const file of fs.readdirSync(dir)) {
+      const full = path.join(dir, file);
+      const stat = fs.statSync(full);
+      if (stat.isDirectory()) {
+        scanDir(full);
+      } else if ((full.endsWith('.ts') || full.endsWith('.js')) && !full.includes('scripts/security-check.js')) {
+        const content = fs.readFileSync(full, 'utf8');
+        for (const pattern of suspiciousPatterns) {
+          if (pattern.test(content)) {
+            console.error(`Suspicious pattern ${pattern} found in ${full}`);
+            flagged = true;
+          }
+        }
+      }
+    }
+  }
+  scanDir('src');
+  if (flagged) {
+    process.exitCode = 1;
+  } else {
+    console.log('Source scan clean');
+  }
+}
+
+runAudit();
+scanSource();


### PR DESCRIPTION
## Summary
- add a SECURITY.md with threat model and disclosure instructions
- introduce a security-check script for CI
- run the new scan in CI workflow
- display CI badge
- document security measures in README

## Testing
- `npm test`
- `npm run security-check`


------
https://chatgpt.com/codex/tasks/task_e_68808e7d34248332abfe92f629378749