### PR TITLE
Improve SHTTP resilience and discovery support

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -39,6 +39,7 @@ startCommand:
   command: node build/index.js
   env:
     MCP_HTTP_PORT: "3000"
+    MCP_DISCOVERY_MODE: "1"
 
 http:
   endpoint: "/mcp"

--- a/src/tools/vibeCheck.ts
+++ b/src/tools/vibeCheck.ts
@@ -26,7 +26,7 @@ export interface VibeCheckOutput {
  * The userRequest parameter MUST contain the full original request for safety.
  */
 export async function vibeCheckTool(input: VibeCheckInput): Promise<VibeCheckOutput> {
-  console.error('vibeCheckTool called with input:', input);
+  console.log('[vibe_check] called', { hasSession: Boolean(input.sessionId) });
   try {
     // Get history summary
     const historySummary = getHistorySummary(input.sessionId);


### PR DESCRIPTION
## Summary
- add optional discovery mode to tolerate empty probe inputs while preserving strict `InvalidParams` for users
- enrich tool schemas with examples and tighten param validation
- expose `/healthz` endpoint and graceful shutdown handlers
- tone down non-error logging
- enable discovery mode in Smithery config

## Testing
- `npm run build`
- `npm test`
- `curl -s localhost:3000/healthz`
- `curl -s -X POST http://localhost:3000/mcp -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'`
- `curl -s -X POST http://localhost:3000/mcp -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"vibe_check","arguments":{}}}'`
- `curl -s -X POST http://localhost:3000/mcp -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"vibe_check","arguments":{}}}'` (without discovery)
- `curl -s -X POST http://localhost:3000/mcp -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"vibe_check","arguments":{"goal":"Ship CPI v2.5","plan":"1) tests 2) refactor 3) canary"}}}'`


------
https://chatgpt.com/codex/tasks/task_e_68b93a207b2c83329a89506dad0e32dc