### PR TITLE
feat: honor standard PORT variable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -306,7 +306,7 @@ async function main() {
     res.status(200).json({ status: 'ok' });
   });
 
-  const PORT = Number(process.env.MCP_HTTP_PORT || 3000);
+  const PORT = Number(process.env.PORT || process.env.MCP_HTTP_PORT || 3000);
   const listener = app.listen(PORT, () => {
     const addr = listener.address();
     const actualPort = typeof addr === 'object' && addr ? addr.port : PORT;

--- a/src/index.ts
+++ b/src/index.ts
@@ -306,7 +306,7 @@ async function main() {
     res.status(200).json({ status: 'ok' });
   });
 
-  const PORT = Number(process.env.PORT || process.env.MCP_HTTP_PORT || 3000);
+  const PORT = Number(process.env.MCP_HTTP_PORT || process.env.PORT || 3000);
   const listener = app.listen(PORT, () => {
     const addr = listener.address();
     const actualPort = typeof addr === 'object' && addr ? addr.port : PORT;

--- a/tests/startup.test.ts
+++ b/tests/startup.test.ts
@@ -7,57 +7,65 @@ import net from 'net';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-describe('Server Startup and Response Time', () => {
-  it('should start and respond to a tools/list request over HTTP', async () => {
-    const startTime = Date.now();
+async function runStartupTest(envVar: 'MCP_HTTP_PORT' | 'PORT') {
+  const startTime = Date.now();
 
-    const projectRoot = path.resolve(__dirname, '..');
-    const indexPath = path.join(projectRoot, 'build', 'index.js');
+  const projectRoot = path.resolve(__dirname, '..');
+  const indexPath = path.join(projectRoot, 'build', 'index.js');
 
-    const port = await new Promise<number>((resolve, reject) => {
-      const s = net.createServer();
-      s.listen(0, () => {
-        const p = (s.address() as any).port;
-        s.close(() => resolve(p));
-      });
-      s.on('error', reject);
+  const port = await new Promise<number>((resolve, reject) => {
+    const s = net.createServer();
+    s.listen(0, () => {
+      const p = (s.address() as any).port;
+      s.close(() => resolve(p));
     });
+    s.on('error', reject);
+  });
 
-    const serverProcess = spawn('node', [indexPath], {
-      env: { ...process.env, MCP_HTTP_PORT: String(port) },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+  const serverProcess = spawn('node', [indexPath], {
+    env: { ...process.env, [envVar]: String(port) },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
 
-    try {
-      let res: Response | null = null;
-      for (let i = 0; i < 40; i++) {
-        try {
-          const attempt = await fetch(`http://localhost:${port}/mcp`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Accept: 'application/json, text/event-stream'
-            },
-            body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }),
-          });
-          if (attempt.status === 200) {
-            res = attempt;
-            break;
-          }
-        } catch {}
-        await new Promise((r) => setTimeout(r, 250));
-      }
-      if (!res) throw new Error('Server did not start');
-      const text = await res.text();
-      const line = text.split('\n').find((l) => l.startsWith('data: '));
-      const json = line ? JSON.parse(line.slice(6)) : null;
-
-      const duration = Date.now() - startTime;
-      expect(res.status).toBe(200);
-      expect(json?.result?.tools.some((t: any) => t.name === 'update_constitution')).toBe(true);
-      expect(duration).toBeLessThan(5000);
-    } finally {
-      serverProcess.kill();
+  try {
+    let res: Response | null = null;
+    for (let i = 0; i < 40; i++) {
+      try {
+        const attempt = await fetch(`http://localhost:${port}/mcp`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json, text/event-stream'
+          },
+          body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }),
+        });
+        if (attempt.status === 200) {
+          res = attempt;
+          break;
+        }
+      } catch {}
+      await new Promise((r) => setTimeout(r, 250));
     }
+    if (!res) throw new Error('Server did not start');
+    const text = await res.text();
+    const line = text.split('\n').find((l) => l.startsWith('data: '));
+    const json = line ? JSON.parse(line.slice(6)) : null;
+
+    const duration = Date.now() - startTime;
+    expect(res.status).toBe(200);
+    expect(json?.result?.tools.some((t: any) => t.name === 'update_constitution')).toBe(true);
+    expect(duration).toBeLessThan(5000);
+  } finally {
+    serverProcess.kill();
+  }
+}
+
+describe('Server Startup and Response Time', () => {
+  it('should start and respond to a tools/list request over HTTP using MCP_HTTP_PORT', async () => {
+    await runStartupTest('MCP_HTTP_PORT');
+  }, 10000);
+
+  it('should start and respond to a tools/list request over HTTP using PORT', async () => {
+    await runStartupTest('PORT');
   }, 10000);
 });


### PR DESCRIPTION
## Summary
- allow server to listen on conventional `PORT` env var
- test startup with both `MCP_HTTP_PORT` and `PORT`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b97a109b98833292639d1c7e5c9f7e