### PR TITLE
docs/cpi-integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@
 
 ## Table of Contents
 - [What is Vibe Check MCP?](#what-is-vibe-check-mcp)
+- [Overview](#overview)
+- [Architecture](#architecture)
 - [The Problem: Pattern Inertia & Reasoning Lock-In](#the-problem-pattern-inertia--reasoning-lock-in)
 - [Key Features](#key-features)
 - [What's New in v2.5.0](#whats-new-in-v250)
@@ -57,6 +59,14 @@
 ## What is Vibe Check MCP?
 
 Vibe Check MCP is a lightweight server implementing Anthropic's [Model Context Protocol](https://anthropic.com/mcp). It acts as an **AI meta-mentor** for your agents, interrupting pattern inertia with **Chain-Pattern Interrupts (CPI)** to prevent Reasoning Lock-In (RLI). Think of it as a rubber-duck debugger for LLMs – a quick sanity check before your agent goes down the wrong path.
+
+## Overview
+
+Vibe Check MCP pairs a metacognitive signal layer with CPI so agents can pause when risk spikes. VibeCheck surfaces traits, uncertainty, and risk scores; CPI consumes those triggers and enforces an intervention policy before the agent resumes. See the [CPI integration guide](./docs/integrations/cpi.md) and the CPI repo placeholder at <https://github.com/<ORG>/cpi> for wiring details.
+
+## Architecture
+
+Vibe Check runs alongside your agent workflow, emitting signals that downstream overseers like CPI or human reviewers can act on. The high-level component map lives in [docs/architecture.md](./docs/architecture.md), while the CPI handoff diagram and example shim are captured in [docs/integrations/cpi.md](./docs/integrations/cpi.md).
 
 ## The Problem: Pattern Inertia & Reasoning Lock-In
 
@@ -195,6 +205,7 @@ As an autonomous agent you will:
 
 ## Documentation
 - [Agent Prompting Strategies](./docs/agent-prompting.md)
+- [CPI Integration](./docs/integrations/cpi.md)
 - [Advanced Integration](./docs/advanced-integration.md)
 - [Technical Reference](./docs/technical-reference.md)
 - [Automatic Docker Setup](./docs/docker-automation.md)

--- a/docs/_toc.md
+++ b/docs/_toc.md
@@ -1,0 +1,8 @@
+# Documentation map
+
+- [Architecture](./architecture.md)
+- Integrations
+  - [CPI Integration](./integrations/cpi.md)
+- [Advanced Integration](./advanced-integration.md)
+- [Technical Reference](./technical-reference.md)
+- [Agent Prompting](./agent-prompting.md)

--- a/docs/integrations/cpi.md
+++ b/docs/integrations/cpi.md
@@ -1,0 +1,72 @@
+# CPI Integration
+
+## Overview
+> CPI (Chain-Pattern Interrupt): a runtime oversight mechanism for multi-agent systems that mitigates “reasoning lock-in.” It injects interrupts based on policy triggers (pattern detectors, heuristics, or external signals), then resumes or reroutes flow.
+>
+> Core pieces: (1) trigger evaluators, (2) intervention policy (allow/block/route/ask-human), (3) logging & repro harness.
+>
+> Status: repo includes repro evals; “constitution” tool supports per-session rule-sets.
+>
+> Integration intent with VibeCheck: VibeCheck = metacognitive layer (signals/traits/uncertainty). CPI = on-policy interrupter. VibeCheck feeds CPI triggers; CPI acts on them.
+
+CPI composes with VibeCheck by acting as an on-policy interrupter whenever VibeCheck signals a risk spike. Use VibeCheck to surface agent traits, uncertainty, and risk levels, then forward that context to CPI so its policy engine can decide whether to allow, block, reroute, or escalate the next action. The example stub in [`examples/cpi-integration.ts`](../../examples/cpi-integration.ts) illustrates the plumbing you can copy into your own orchestrator.
+
+## Flow diagram
+```mermaid
+flowchart LR
+  AgentStep[Agent step] -->|emit signals| VibeCheck
+  VibeCheck -->|risk + traits| CPI
+  CPI -->|policy decision| AgentController[Agent controller]
+  AgentController -->|resume/adjust| AgentStep
+```
+
+## Minimal integration sketch
+Below is a minimal TypeScript sketch that mirrors the logic in the [`runWithCPI`](../../examples/cpi-integration.ts) example. Replace the TODO markers with the real CPI SDK import when it becomes available.
+
+```ts
+type AgentStep = {
+  sessionId: string;
+  summary: string;
+  nextAction: string;
+};
+
+type VibeCheckSignal = {
+  riskScore: number;
+  advice: string;
+};
+
+async function analyzeWithVibeCheck(step: AgentStep): Promise<VibeCheckSignal> {
+  // TODO: replace with a real call to the VibeCheck MCP server.
+  return { riskScore: Math.random(), advice: `Reflect on: ${step.summary}` };
+}
+
+// TODO: replace with `import { createPolicy } from '@cpi/sdk';`
+function cpiPolicyShim(signal: VibeCheckSignal) {
+  if (signal.riskScore >= 0.6) {
+    return { action: 'interrupt', reason: 'High metacognitive risk from VibeCheck' } as const;
+  }
+  return { action: 'allow' } as const;
+}
+
+export async function evaluateStep(step: AgentStep) {
+  const signal = await analyzeWithVibeCheck(step);
+  const decision = cpiPolicyShim(signal);
+
+  if (decision.action === 'interrupt') {
+    // Pause your agent, collect clarification, or reroute to a human.
+    return { status: 'paused', reason: decision.reason } as const;
+  }
+
+  return { status: 'continue', signal } as const;
+}
+```
+
+### Implementation checklist
+1. Surface VibeCheck scores (risk, traits, uncertainty) alongside the raw advice payload.
+2. Normalize those signals into CPI trigger events (e.g., `riskScore > 0.6`).
+3. Hand the event to a CPI intervention policy and respect the returned directive.
+4. Feed decisions into the CPI logging & repro harness to preserve traces.
+
+## Further reading
+- CPI reference implementation (placeholder): <https://github.com/<ORG>/cpi>
+- VibeCheck + CPI wiring example: [`examples/cpi-integration.ts`](../../examples/cpi-integration.ts)

--- a/examples/cpi-integration.ts
+++ b/examples/cpi-integration.ts
@@ -1,0 +1,97 @@
+/**
+ * Example CPI integration stub for VibeCheck MCP.
+ *
+ * Wire this into your agent orchestrator to forward VibeCheck signals to a CPI policy.
+ */
+
+export interface AgentSnapshot {
+  sessionId: string;
+  summary: string;
+  nextAction: string;
+  done?: boolean;
+}
+
+export interface ResumeSignal {
+  reason: string;
+  followUp?: string;
+}
+
+export interface AgentStepCallback {
+  (input: { resumeSignal?: ResumeSignal }): Promise<AgentSnapshot>;
+}
+
+export interface VibeCheckSignal {
+  riskScore: number;
+  traits: string[];
+  advice: string;
+}
+
+const RISK_THRESHOLD = 0.6;
+
+const vibecheckShim = {
+  // TODO: replace with an actual call to the VibeCheck MCP tool over MCP or HTTP.
+  async analyze(snapshot: AgentSnapshot): Promise<VibeCheckSignal> {
+    return {
+      riskScore: Math.random(),
+      traits: ['focus-drift'],
+      advice: `Reflect on: ${snapshot.summary}`,
+    };
+  },
+};
+
+// TODO: replace with `import { createPolicy } from '@cpi/sdk';`
+const cpiPolicyShim = {
+  interrupt(input: { snapshot: AgentSnapshot; signal: VibeCheckSignal }) {
+    if (input.signal.riskScore >= RISK_THRESHOLD) {
+      return {
+        action: 'interrupt' as const,
+        reason: 'High metacognitive risk detected by VibeCheck',
+      };
+    }
+
+    return { action: 'allow' as const };
+  },
+};
+
+async function handleInterrupt(
+  decision: { action: 'interrupt' | 'allow'; reason?: string },
+  snapshot: AgentSnapshot,
+): Promise<ResumeSignal | undefined> {
+  if (decision.action === 'allow') {
+    return undefined;
+  }
+
+  console.warn('[CPI] interrupting agent step:', decision.reason ?? 'policy requested pause');
+  console.warn('Agent summary:', snapshot.summary);
+
+  // TODO: replace with human-in-the-loop logic or CPI repro harness callback.
+  return {
+    reason: decision.reason ?? 'Paused for inspection',
+    followUp: 'Agent acknowledged CPI feedback and is ready to resume.',
+  };
+}
+
+export async function runWithCPI(agentStep: AgentStepCallback): Promise<void> {
+  let resumeSignal: ResumeSignal | undefined;
+
+  while (true) {
+    const snapshot = await agentStep({ resumeSignal });
+
+    if (snapshot.done) {
+      console.log('Agent workflow completed.');
+      break;
+    }
+
+    const signal = await vibecheckShim.analyze(snapshot);
+    console.log('VibeCheck signal', signal);
+
+    const decision = cpiPolicyShim.interrupt({ snapshot, signal });
+
+    if (decision.action !== 'allow') {
+      resumeSignal = await handleInterrupt(decision, snapshot);
+      continue;
+    }
+
+    resumeSignal = undefined;
+  }
+}


### PR DESCRIPTION
## Summary
- document how CPI composes with VibeCheck and add a dedicated integration guide
- add a CPI integration example stub wiring VibeCheck signals into a policy shim
- cross-link the new guide from the README and docs table of contents

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d91f3040e0833288b71f845e31a422