### PR TITLE
fix: return text JSON for check_constitution to satisfy MCP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ Use a lightweight “constitution” to enforce rules per `sessionId` that CPI w
 **API (tools):**
 - `update_constitution({ sessionId, rules })` → merges/sets rule set for the session
 - `reset_constitution({ sessionId })` → clears session rules
-- `check_constitution({ sessionId })` → returns effective rules for the session
+- `check_constitution({ sessionId })` → returns effective rules for the session as a JSON string in text format for broad MCP client compatibility
+
+**Response Format Note:** The `check_constitution` tool returns its data with `type: 'text'` containing a JSON string (rather than `type: 'json'`) to ensure compatibility with the widest range of MCP clients. Clients will need to parse the text field to access the JSON data.
 
 ## Quickstart & Installation
 ```bash
@@ -200,7 +202,7 @@ As an autonomous agent you will:
 | 🔄 **vibe_learn**       | Capture mistakes, preferences, and successes                 |
 | 🧰 **update_constitution** | Set/merge session rules the CPI layer will enforce         |
 | 🧹 **reset_constitution**  | Clear rules for a session                                  |
-| 🔎 **check_constitution**  | Inspect effective rules for a session                      |
+| 🔎 **check_constitution**  | Inspect effective rules for a session (returns JSON as text for MCP compatibility) |
 
 ## Documentation
 - [Agent Prompting Strategies](./docs/agent-prompting.md)

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,7 +271,7 @@ async function main() {
         }
         const rules = getConstitution(args.sessionId);
         console.log('[Constitution:check]', { sessionId: args.sessionId, count: rules.length });
-        return { content: [{ type: 'json', json: { rules } }] };
+        return { content: [{ type: 'text', text: JSON.stringify({ rules }) }] };
       }
 
       default:

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import net from 'net';
+import { randomUUID } from 'crypto';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function runCheckConstitutionTest() {
+  const startTime = Date.now();
+
+  const projectRoot = path.resolve(__dirname, '..');
+  const indexPath = path.join(projectRoot, 'build', 'index.js');
+
+  const getPort = () =>
+    new Promise<number>((resolve, reject) => {
+      const s = net.createServer();
+      s.listen(0, () => {
+        const p = (s.address() as any).port;
+        s.close(() => resolve(p));
+      });
+      s.on('error', reject);
+    });
+
+  const port = await getPort();
+  const env: NodeJS.ProcessEnv = { ...process.env, MCP_HTTP_PORT: String(port) };
+
+  const serverProcess = spawn('node', [indexPath], {
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  try {
+    let res: Response | null = null;
+    const requestId = 1;
+    const sessionId = randomUUID();
+
+    // Wait for server to be ready
+    for (let i = 0; i < 40; i++) {
+      try {
+        const attempt = await fetch(`http://localhost:${port}/mcp`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json, text/event-stream'
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: requestId,
+            method: 'tools/list',
+            params: {}
+          }),
+        });
+        if (attempt.status === 200) {
+          res = attempt;
+          break;
+        }
+      } catch {}
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    if (!res) throw new Error('Server did not start');
+
+    // Now make the actual check_constitution call
+    const response = await fetch(`http://localhost:${port}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream'
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: requestId + 1,
+        method: 'tools/call',
+        params: {
+          name: 'check_constitution',
+          arguments: {
+            sessionId,
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+
+    const text = await response.text();
+    const lines = text.split('\n');
+    const dataLine = lines.find((l) => l.startsWith('data: '));
+
+    if (!dataLine) {
+      throw new Error('No data line found in response');
+    }
+
+    const json = JSON.parse(dataLine.slice(6));
+
+    // Validate the response structure
+    expect(json).toHaveProperty('result');
+    expect(json.result).toHaveProperty('content');
+    expect(Array.isArray(json.result.content)).toBe(true);
+    expect(json.result.content.length).toBe(1);
+
+    // Validate the content type is 'text' (not 'json')
+    const firstContent = json.result.content[0];
+    expect(firstContent.type).toBe('text');
+    expect(typeof firstContent.text).toBe('string');
+
+    // Validate the nested JSON within the 'text' field
+    const parsedText = JSON.parse(firstContent.text);
+    expect(parsedText).toHaveProperty('rules');
+    expect(Array.isArray(parsedText.rules)).toBe(true);
+
+    const duration = Date.now() - startTime;
+    expect(duration).toBeLessThan(5000);
+  } finally {
+    serverProcess.kill();
+  }
+}
+
+describe('Tool Call Integration Tests', () => {
+  it('check_constitution returns text content with rules array', async () => {
+    await runCheckConstitutionTest();
+  }, 10000);
+});


### PR DESCRIPTION
## Problem
  The check_constitution tool was returning { type: 'json' } which caused validation errors in strict MCP clients that enforce a narrower union of content item types.

  ## Solution
  - Changed check_constitution handler to return { type: 'text', text: JSON.stringify({ rules }) } instead of { type: 'json', json: { rules } }        
  - Added HTTP integration test to validate response format
  - Updated README documentation to clarify the response format

  ## Changes
  - **src/index.ts**: Fixed content type from 'json' to 'text'
  - **tests/tools.test.ts**: Added comprehensive HTTP integration test
  - **README.md**: Updated documentation for MCP client compatibility

  ## Verification
  - ✅ All 17 tests pass (including new HTTP integration test)
  - ✅ Response format validated: content[0].type === 'text' with parsable JSON
  - ✅ No regressions in existing functionality
  - ✅ Compatible with both stdio and HTTP transports

  This ensures the widest MCP client compatibility while maintaining all
  existing functionality.