### PR TITLE
Document stdio transport requirement for Claude Desktop integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,17 @@ Add to `claude_desktop_config.json`:
 "vibe-check": {
   "command": "node",
   "args": ["/path/to/vibe-check-mcp/build/index.js"],
-  "env": { "GEMINI_API_KEY": "YOUR_GEMINI_API_KEY" }
+  "env": {
+    "GEMINI_API_KEY": "YOUR_GEMINI_API_KEY",
+    "MCP_TRANSPORT": "stdio"
+  }
 }
 ```
+
+Claude Desktop (including Claude Code auto-start on macOS) talks MCP over stdio. If
+`MCP_TRANSPORT` is not set to `stdio`, the server defaults to HTTP mode and the
+desktop app will hang while trying to connect. After editing the configuration,
+restart Claude Desktop so it reloads the MCP registry.
 
 ## Research & Philosophy
 


### PR DESCRIPTION
## Summary
- update the Claude Desktop configuration example to include the MCP stdio transport
- document why the environment variable is required for Claude Desktop and Claude Code auto-start connections

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e8de9660bc8332a2d9ca92b305ea27