### PR TITLE
feat(cli): add npx bin and Node 20 engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Introduce CLI scaffold and npx bin (no commands yet).

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 - [The Problem: Pattern Inertia & Reasoning Lock-In](#the-problem-pattern-inertia--reasoning-lock-in)
 - [Key Features](#key-features)
 - [What's New in v2.5.0](##-What's-New-in-v2.5.1)
+- [Quickstart (npx)](#quickstart-npx)
 - [Quickstart & Installation](#quickstart--installation)
 - [Usage Examples](#usage-examples)
 - [Adaptive Metacognitive Interrupts (CPI)](#adaptive-metacognitive-interrupts-cpi)
@@ -91,6 +92,12 @@ Use a lightweight “constitution” to enforce rules per `sessionId` that CPI w
 - `reset_constitution({ sessionId })` → clears session rules
 - `check_constitution({ sessionId })` → returns effective rules for the session
 
+## Quickstart (npx)
+```bash
+npx @pv-bhat/vibe-check-mcp --help
+# start/install/doctor coming in next release
+```
+
 ## Quickstart & Installation
 ```bash
 # Clone and install
@@ -99,7 +106,7 @@ cd vibe-check-mcp-server
 npm install
 npm run build
 ```
-This project targets Node **20+**. If you see a TypeScript error about a duplicate `require` declaration when building with Node 20.19.3, ensure your dependencies are up to date (`npm install`) or use the Docker setup below which handles the build automatically.
+This project targets Node **>=20**. If you see a TypeScript error about a duplicate `require` declaration when building with Node 20.19.3, ensure your dependencies are up to date (`npm install`) or use the Docker setup below which handles the build automatically.
 
 Create a `.env` file with the API keys you plan to use:
 ```bash

--- a/package.json
+++ b/package.json
@@ -5,11 +5,14 @@
   "description": "Metacognitive AI agent oversight: adaptive CPI interrupts for alignment, reflection and safety",
   "main": "build/index.js",
   "type": "module",
+  "bin": {
+    "vibe-check-mcp": "build/cli/index.js"
+  },
   "files": [
     "build"
   ],
   "scripts": {
-    "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
+    "build": "tsc && node -e \"const fs=require('fs');['build/index.js','build/cli/index.js'].forEach((f)=>{if(fs.existsSync(f)){fs.chmodSync(f,0o755);}})\"",
     "prepare": "npm run build",
     "start": "node build/index.js",
     "dev": "tsc-watch --onSuccess \"node build/index.js\"",
@@ -37,7 +40,7 @@
     "vitest": "^3.2.4"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "keywords": [
     "mcp",

--- a/scripts/install-vibe-check.sh
+++ b/scripts/install-vibe-check.sh
@@ -32,25 +32,25 @@ if [ "$OS" = "Unknown" ]; then
     exit 1
 fi
 
-echo "Step 1: Installing vibe-check-mcp globally..."
-npm install -g vibe-check-mcp
+echo "Step 1: Installing @pv-bhat/vibe-check-mcp globally..."
+npm install -g @pv-bhat/vibe-check-mcp
 
 if [ $? -ne 0 ]; then
-    echo "Error: Failed to install vibe-check-mcp globally."
+    echo "Error: Failed to install @pv-bhat/vibe-check-mcp globally."
     exit 1
 fi
 
 echo ""
 echo "Step 2: Finding global npm installation path..."
 NPM_GLOBAL=$(npm root -g)
-VIBE_CHECK_PATH="$NPM_GLOBAL/vibe-check-mcp/build/index.js"
+VIBE_CHECK_PATH="$NPM_GLOBAL/@pv-bhat/vibe-check-mcp/build/index.js"
 
 if [ ! -f "$VIBE_CHECK_PATH" ]; then
-    echo "Error: Could not find vibe-check-mcp installation at $VIBE_CHECK_PATH"
+    echo "Error: Could not find @pv-bhat/vibe-check-mcp installation at $VIBE_CHECK_PATH"
     exit 1
 fi
 
-echo "Found vibe-check-mcp at: $VIBE_CHECK_PATH"
+echo "Found @pv-bhat/vibe-check-mcp at: $VIBE_CHECK_PATH"
 echo ""
 
 echo "Step 3: Enter your Gemini API key for vibe-check-mcp..."

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const HELP_TEXT = `vibe-check-mcp CLI (preview)
+
+Usage:
+  npx @pv-bhat/vibe-check-mcp --help
+  npx @pv-bhat/vibe-check-mcp --version
+
+Flags:
+  -h, --help     Show this help message
+  -v, --version  Print the CLI version
+
+Commands for starting the server are coming in a future release.`;
+
+function getVersion(): string {
+  const cliDir = dirname(fileURLToPath(import.meta.url));
+  const packageJsonPath = resolve(cliDir, '..', '..', 'package.json');
+  const raw = readFileSync(packageJsonPath, 'utf8');
+  const pkg = JSON.parse(raw) as { version?: string };
+  return pkg.version ?? '0.0.0';
+}
+
+function printHelp() {
+  console.log(HELP_TEXT);
+}
+
+const args = process.argv.slice(2);
+
+if (args.some((arg) => arg === '--version' || arg === '-v')) {
+  console.log(getVersion());
+  process.exit(0);
+}
+
+if (args.length === 0 || args.some((arg) => arg === '--help' || arg === '-h')) {
+  printHelp();
+  process.exit(0);
+}
+
+printHelp();
+process.exit(0);

--- a/tests/cli-version.test.ts
+++ b/tests/cli-version.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+describe('CLI version', () => {
+  it('prints the package version', () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const projectRoot = resolve(__dirname, '..');
+    const cliPath = resolve(projectRoot, 'build', 'cli', 'index.js');
+    expect(existsSync(cliPath)).toBe(true);
+
+    const output = execFileSync('node', [cliPath, '--version'], { encoding: 'utf8' }).trim();
+    const pkg = JSON.parse(readFileSync(resolve(projectRoot, 'package.json'), 'utf8')) as { version: string };
+
+    expect(output).toBe(pkg.version);
+  });
+});


### PR DESCRIPTION
## Summary
- wire up a scoped CLI entry point and build output so `npx @pv-bhat/vibe-check-mcp` resolves to the compiled stub
- require Node.js 20+, adjust build permissions for the CLI artifact, and update installer/docs to reference the scoped package
- document the new scaffold in the changelog and add a regression test to confirm the CLI reports the published version

## Testing
- npm run build
- npm test
- node build/cli/index.js --help
- npm pack --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68e8f0cf0d9883328be5e53b2d86a668