### PR TITLE
feat(cli): add install --client claude with idempotent config merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,23 +155,29 @@ docker build -t vibe-check-mcp .
 docker run -e GEMINI_API_KEY=your_gemini_api_key -p 3000:3000 vibe-check-mcp
 ```
 
-### Integrating with Claude Desktop
-Add to `claude_desktop_config.json`:
-```json
-"vibe-check": {
-  "command": "node",
-  "args": ["/path/to/vibe-check-mcp/build/index.js"],
-  "env": {
-    "GEMINI_API_KEY": "YOUR_GEMINI_API_KEY",
-    "MCP_TRANSPORT": "stdio"
-  }
-}
+### Install (Claude Desktop)
+
+Register the Vibe Check MCP server as a local Claude Desktop integration:
+
+```bash
+npx @pv-bhat/vibe-check-mcp install --client claude
+
+# Non-interactive (e.g. CI) when env is already populated
+VIBE_CHECK_API_KEY=... npx @pv-bhat/vibe-check-mcp install --client claude --non-interactive
 ```
 
-Claude Desktop (including Claude Code auto-start on macOS) talks MCP over stdio. If
-`MCP_TRANSPORT` is not set to `stdio`, the server defaults to HTTP mode and the
-desktop app will hang while trying to connect. After editing the configuration,
-restart Claude Desktop so it reloads the MCP registry.
+The installer merges an entry under `mcpServers.vibe-check-mcp`, tagged with a
+`managedBy: "vibe-check-mcp-cli"` sentinel for safe updates/uninstalls. Secrets
+are sourced from the environment, your project `.env`, and finally
+`~/.vibe-check/.env` (the default write location). If required keys are missing
+and you are in interactive mode, the CLI prompts once and stores them with
+`0600` permissions. For unattended environments, provide the variables up front
+with `--non-interactive`.
+
+This command configures Claude for local **STDIO** usage via the packaged CLI.
+Remote HTTP servers should continue to be registered through Claude’s desktop UI
+for connectors. See [Claude’s MCP documentation](https://support.anthropic.com)
+for the schema reference used by the installer.
 
 ## Research & Philosophy
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "body-parser": "^1.20.2",
         "commander": "^12.1.0",
         "cors": "^2.8.5",
+        "diff": "^5.2.0",
         "dotenv": "^16.4.7",
         "execa": "^9.5.1",
         "express": "^4.19.2",
@@ -26,6 +27,7 @@
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
+        "@types/diff": "^5.2.3",
         "@types/express": "^4.17.21",
         "@types/node": "^20.17.25",
         "@types/semver": "^7.7.1",
@@ -1249,6 +1251,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/diff": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.2.3.tgz",
+      "integrity": "sha512-K0Oqlrq3kQMaO2RhfrNQX5trmt+XLyom88zS0u84nnIcLvFnRUMRRHmrGny5GSM+kNO9IZLARsdQHDzkhAgmrQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1947,6 +1956,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dotenv": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "body-parser": "^1.20.2",
     "commander": "^12.1.0",
     "cors": "^2.8.5",
+    "diff": "^5.2.0",
     "dotenv": "^16.4.7",
     "execa": "^9.5.1",
     "express": "^4.19.2",
@@ -36,6 +37,7 @@
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
+    "@types/diff": "^5.2.3",
     "@types/express": "^4.17.21",
     "@types/node": "^20.17.25",
     "@types/semver": "^7.7.1",

--- a/src/cli/clients/claude.ts
+++ b/src/cli/clients/claude.ts
@@ -1,0 +1,151 @@
+import { constants as fsConstants } from 'node:fs';
+import { access, copyFile, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { basename, dirname, join, resolve } from 'node:path';
+import os from 'node:os';
+
+const backupsCreated = new Set<string>();
+
+export function claudeConfigCandidates(): string[] {
+  const home = os.homedir();
+  const paths: string[] = [];
+
+  if (process.platform === 'darwin') {
+    paths.push(join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json'));
+  } else if (process.platform === 'win32') {
+    const appData = process.env.APPDATA ?? join(home, 'AppData', 'Roaming');
+    paths.push(join(appData, 'Claude', 'claude_desktop_config.json'));
+  } else {
+    const xdgHome = process.env.XDG_CONFIG_HOME ?? join(home, '.config');
+    paths.push(join(xdgHome, 'Claude', 'claude_desktop_config.json'));
+    paths.push(join(home, '.config', 'Claude', 'claude_desktop_config.json'));
+  }
+
+  return paths;
+}
+
+export async function locateClaudeConfig(customPath?: string): Promise<string | null> {
+  if (customPath) {
+    return resolve(customPath);
+  }
+
+  for (const candidate of claudeConfigCandidates()) {
+    try {
+      await access(candidate, fsConstants.F_OK);
+      return candidate;
+    } catch {
+      // Continue scanning
+    }
+  }
+
+  return null;
+}
+
+export async function readClaudeConfig(path: string): Promise<any> {
+  const raw = await readFile(path, 'utf8');
+  return JSON.parse(raw);
+}
+
+function formatTimestamp(date: Date): string {
+  return date.toISOString().replace(/[:.]/g, '-');
+}
+
+async function ensureBackup(path: string): Promise<void> {
+  if (backupsCreated.has(path)) {
+    return;
+  }
+
+  try {
+    await access(path, fsConstants.F_OK);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+
+  const dir = dirname(path);
+  const stamp = formatTimestamp(new Date());
+  const backupName = `${basename(path)}.${stamp}.${process.pid}.bak`;
+  const backupPath = join(dir, backupName);
+  await mkdir(dir, { recursive: true });
+  await copyFile(path, backupPath);
+  backupsCreated.add(path);
+}
+
+export async function writeClaudeConfigAtomic(path: string, data: any): Promise<void> {
+  await ensureBackup(path);
+
+  const dir = dirname(path);
+  const tempName = `${basename(path)}.${process.pid}.${Date.now()}.tmp`;
+  const tempPath = join(dir, tempName);
+  const serialized = `${JSON.stringify(data, null, 2)}\n`;
+
+  await mkdir(dir, { recursive: true });
+  await writeFile(tempPath, serialized, { mode: 0o600 });
+
+  try {
+    await rename(tempPath, path);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'EEXIST') {
+      await rm(path, { force: true });
+      await rename(tempPath, path);
+    } else {
+      await rm(tempPath, { force: true });
+      throw error;
+    }
+  }
+}
+
+type MergeOptions = {
+  id: string;
+  sentinel: string;
+};
+
+type MergeResult = {
+  next: any;
+  changed: boolean;
+  reason?: string;
+};
+
+export function mergeMcpEntry(cfg: any, entry: any, options: MergeOptions): MergeResult {
+  const { id, sentinel } = options;
+  const baseConfig = cfg && typeof cfg === 'object' ? cfg : {};
+  const nextConfig = Array.isArray(baseConfig) ? {} : JSON.parse(JSON.stringify(baseConfig));
+
+  const currentServers = nextConfig.mcpServers && typeof nextConfig.mcpServers === 'object'
+    ? { ...nextConfig.mcpServers }
+    : {};
+
+  const existing = currentServers[id];
+
+  const managedEntry = { ...entry, managedBy: sentinel };
+
+  if (existing) {
+    if (existing.managedBy !== sentinel) {
+      return {
+        next: cfg,
+        changed: false,
+        reason: 'existing entry without sentinel',
+      };
+    }
+
+    const serializedExisting = JSON.stringify(existing);
+    const serializedNext = JSON.stringify(managedEntry);
+    if (serializedExisting === serializedNext) {
+      return { next: cfg, changed: false };
+    }
+
+    currentServers[id] = managedEntry;
+    return {
+      next: { ...nextConfig, mcpServers: currentServers },
+      changed: true,
+    };
+  }
+
+  currentServers[id] = managedEntry;
+  return {
+    next: { ...nextConfig, mcpServers: currentServers },
+    changed: true,
+  };
+}

--- a/src/cli/env.ts
+++ b/src/cli/env.ts
@@ -1,10 +1,16 @@
-import { existsSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { promises as fs } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import os from 'node:os';
+import { parse as parseEnv } from 'dotenv';
+import { createInterface } from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
 
 export function homeConfigDir(): string {
   return join(os.homedir(), '.vibe-check');
 }
+
+export const REQUIRED_ENV_KEYS = ['VIBE_CHECK_API_KEY'] as const;
 
 export function resolveEnvSources(): {
   cwdEnv: string | null;
@@ -19,4 +25,116 @@ export function resolveEnvSources(): {
     homeEnv: existsSync(homeEnvPath) ? homeEnvPath : null,
     processEnv: process.env,
   };
+}
+
+type EnsureEnvOptions = {
+  interactive: boolean;
+  local: boolean;
+};
+
+type EnsureEnvResult = {
+  wrote: boolean;
+  path?: string;
+  missingKeys?: string[];
+};
+
+function readEnvMap(path: string | null): Record<string, string> {
+  if (!path || !existsSync(path)) {
+    return {};
+  }
+
+  try {
+    const raw = readFileSync(path, 'utf8');
+    return parseEnv(raw);
+  } catch (error) {
+    console.warn(`Failed to read env file at ${path}: ${(error as Error).message}`);
+    return {};
+  }
+}
+
+function serializeEnv(env: Record<string, string>): string {
+  const keys = Object.keys(env).sort();
+  return keys
+    .map((key) => `${key}=${env[key]}`)
+    .join('\n')
+    .concat(keys.length ? '\n' : '');
+}
+
+async function atomicWriteEnv(path: string, content: string): Promise<void> {
+  const tempPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+  await fs.mkdir(dirname(path), { recursive: true });
+  await fs.writeFile(tempPath, content, { mode: 0o600 });
+  try {
+    await fs.rename(tempPath, path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      await fs.rm(path, { force: true });
+      await fs.rename(tempPath, path);
+    } else {
+      await fs.rm(tempPath, { force: true });
+      throw error;
+    }
+  }
+}
+
+export async function ensureEnv(options: EnsureEnvOptions): Promise<EnsureEnvResult> {
+  const { interactive, local } = options;
+  const sources = resolveEnvSources();
+  const cwdMap = readEnvMap(sources.cwdEnv);
+  const homeMap = readEnvMap(sources.homeEnv);
+
+  const missing: string[] = [];
+
+  for (const key of REQUIRED_ENV_KEYS) {
+    const resolved =
+      process.env[key] ?? (local ? cwdMap[key] : undefined) ?? cwdMap[key] ?? homeMap[key];
+    if (resolved) {
+      process.env[key] = resolved;
+    } else {
+      missing.push(key);
+    }
+  }
+
+  if (missing.length === 0) {
+    return { wrote: false };
+  }
+
+  if (!interactive) {
+    console.warn(`Missing required environment variables: ${missing.join(', ')}`);
+    return { wrote: false, missingKeys: missing };
+  }
+
+  const targetDir = local ? process.cwd() : homeConfigDir();
+  const targetPath = resolve(targetDir, '.env');
+  const targetMap = local ? { ...cwdMap } : { ...homeMap };
+
+  const rl = createInterface({ input, output });
+  try {
+    for (const key of missing) {
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const answer = (await rl.question(`${key}: `)).trim();
+        if (answer) {
+          targetMap[key] = answer;
+          process.env[key] = answer;
+          break;
+        }
+      }
+    }
+
+    const targetExists = existsSync(targetPath);
+    if (targetExists) {
+      const confirmation = (await rl.question(`Update ${targetPath}? (y/N) `)).trim().toLowerCase();
+      if (confirmation !== 'y' && confirmation !== 'yes') {
+        console.warn('Aborted writing environment file.');
+        return { wrote: false, path: targetPath, missingKeys: missing };
+      }
+    }
+  } finally {
+    rl.close();
+  }
+
+  const content = serializeEnv(targetMap);
+  await atomicWriteEnv(targetPath, content);
+  return { wrote: true, path: targetPath };
 }

--- a/src/cli/utils/diff.ts
+++ b/src/cli/utils/diff.ts
@@ -1,0 +1,6 @@
+import { createTwoFilesPatch } from 'diff';
+
+export function renderUnifiedDiff(oldPath: string, newPath: string, oldContent: string, newContent: string): string {
+  const patch = createTwoFilesPatch(oldPath, newPath, oldContent, newContent, '', '', { context: 3 });
+  return patch.trim() ? patch : 'No changes.';
+}

--- a/tests/claude-merge.test.ts
+++ b/tests/claude-merge.test.ts
@@ -1,0 +1,97 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, afterAll } from 'vitest';
+import { mergeMcpEntry, writeClaudeConfigAtomic } from '../src/cli/clients/claude.js';
+
+const SENTINEL = 'vibe-check-mcp-cli';
+const ENTRY = {
+  command: 'npx',
+  args: ['@pv-bhat/vibe-check-mcp', 'start', '--stdio'],
+  env: {},
+  managedBy: SENTINEL,
+};
+
+async function readFixture(name: string): Promise<any> {
+  const path = join(process.cwd(), 'tests', 'fixtures', 'claude', name);
+  const raw = await fs.readFile(path, 'utf8');
+  return JSON.parse(raw);
+}
+
+describe('mergeMcpEntry', () => {
+  it('appends managed entry when missing', async () => {
+    const base = await readFixture('config.base.json');
+    const result = mergeMcpEntry(base, ENTRY, { id: 'vibe-check-mcp', sentinel: SENTINEL });
+
+    expect(result.changed).toBe(true);
+    expect(result.next).toMatchInlineSnapshot(`
+      {
+        "mcpServers": {
+          "vibe-check-mcp": {
+            "args": [
+              "@pv-bhat/vibe-check-mcp",
+              "start",
+              "--stdio",
+            ],
+            "command": "npx",
+            "env": {},
+            "managedBy": "vibe-check-mcp-cli",
+          },
+        },
+        "theme": "system",
+      }
+    `);
+  });
+
+  it('updates existing managed entry', async () => {
+    const base = await readFixture('config.with-managed-entry.json');
+    const updatedEntry = {
+      ...ENTRY,
+      args: ['@pv-bhat/vibe-check-mcp', 'start', '--stdio', '--http'],
+    };
+
+    const result = mergeMcpEntry(base, updatedEntry, { id: 'vibe-check-mcp', sentinel: SENTINEL });
+
+    expect(result.changed).toBe(true);
+    expect(result.next.mcpServers['vibe-check-mcp'].args).toEqual(updatedEntry.args);
+    expect(result.next.mcpServers.other).toEqual(base.mcpServers.other);
+  });
+
+  it('does not modify unmanaged entries', async () => {
+    const base = await readFixture('config.with-other-servers.json');
+    const result = mergeMcpEntry(base, ENTRY, { id: 'vibe-check-mcp', sentinel: SENTINEL });
+
+    expect(result.changed).toBe(false);
+    expect(result.reason).toBe('existing entry without sentinel');
+  });
+});
+
+describe('writeClaudeConfigAtomic', () => {
+  const tempDirs: string[] = [];
+
+  afterAll(async () => {
+    await Promise.all(tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  it('creates a backup and writes new config', async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'claude-config-'));
+    tempDirs.push(dir);
+    const configPath = join(dir, 'claude_desktop_config.json');
+
+    const base = await readFixture('config.with-managed-entry.json');
+    await fs.writeFile(configPath, `${JSON.stringify(base, null, 2)}\n`);
+
+    const merged = mergeMcpEntry(base, ENTRY, { id: 'vibe-check-mcp', sentinel: SENTINEL });
+    await writeClaudeConfigAtomic(configPath, merged.next);
+
+    const files = await fs.readdir(dir);
+    const backup = files.find((file) => file.endsWith('.bak'));
+    expect(backup).toBeDefined();
+
+    const finalRaw = await fs.readFile(configPath, 'utf8');
+    expect(JSON.parse(finalRaw)).toEqual(merged.next);
+
+    const backupRaw = await fs.readFile(join(dir, backup!), 'utf8');
+    expect(JSON.parse(backupRaw)).toEqual(base);
+  });
+});

--- a/tests/cli-install-dry-run.test.ts
+++ b/tests/cli-install-dry-run.test.ts
@@ -1,0 +1,45 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createCliProgram } from '../src/cli/index.js';
+
+async function copyFixture(): Promise<{ configPath: string; dir: string }> {
+  const sourcePath = join(process.cwd(), 'tests', 'fixtures', 'claude', 'config.base.json');
+  const dir = await fs.mkdtemp(join(tmpdir(), 'claude-dryrun-'));
+  const target = join(dir, 'claude_desktop_config.json');
+  const data = await fs.readFile(sourcePath, 'utf8');
+  await fs.writeFile(target, data);
+  return { configPath: target, dir };
+}
+
+afterEach(() => {
+  delete process.env.VIBE_CHECK_API_KEY;
+  vi.restoreAllMocks();
+});
+
+describe('cli install --dry-run', () => {
+  it('prints a diff without modifying the config file', async () => {
+    const { configPath, dir } = await copyFixture();
+    const original = await fs.readFile(configPath, 'utf8');
+    process.env.VIBE_CHECK_API_KEY = 'test-key';
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const program = createCliProgram();
+    await program.parseAsync(
+      ['install', '--client', 'claude', '--dry-run', '--non-interactive', '--config', configPath],
+      { from: 'user' },
+    );
+
+    const updated = await fs.readFile(configPath, 'utf8');
+    expect(updated).toBe(original);
+
+    const combinedLogs = [...logSpy.mock.calls.flat(), ...warnSpy.mock.calls.flat()].join('\n');
+    expect(combinedLogs).toContain('Dry run: no changes written');
+    expect(combinedLogs).toContain('@@');
+
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+});

--- a/tests/env-ensure.test.ts
+++ b/tests/env-ensure.test.ts
@@ -1,0 +1,70 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import os from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const prompts: string[] = [];
+const answers: string[] = [];
+const closers: Array<() => void> = [];
+
+vi.mock('node:readline/promises', () => ({
+  createInterface: () => ({
+    question: (prompt: string) => {
+      prompts.push(prompt);
+      const answer = answers.shift() ?? '';
+      return Promise.resolve(answer);
+    },
+    close: () => {
+      const closer = closers.shift();
+      closer?.();
+    },
+  }),
+}));
+
+import { ensureEnv } from '../src/cli/env.js';
+
+function resetQueues(): void {
+  prompts.length = 0;
+  answers.length = 0;
+  closers.length = 0;
+}
+
+afterEach(() => {
+  delete process.env.VIBE_CHECK_API_KEY;
+  resetQueues();
+  vi.restoreAllMocks();
+});
+
+describe('ensureEnv', () => {
+  it('skips writing when env is already provided in non-interactive mode', async () => {
+    process.env.VIBE_CHECK_API_KEY = 'present';
+
+    const result = await ensureEnv({ interactive: false, local: false });
+
+    expect(result.wrote).toBe(false);
+    expect(prompts).toHaveLength(0);
+  });
+
+  it('prompts for missing secrets and writes ~/.vibe-check/.env', async () => {
+    const tempHome = await fs.mkdtemp(join(tmpdir(), 'env-home-'));
+    const homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(tempHome);
+    const closeSpy = vi.fn();
+    closers.push(closeSpy);
+    answers.push('secret-value');
+
+    const result = await ensureEnv({ interactive: true, local: false });
+
+    expect(result.wrote).toBe(true);
+    expect(result.path).toBe(join(tempHome, '.vibe-check', '.env'));
+    const stat = await fs.stat(result.path!);
+    expect(stat.mode & 0o777).toBe(0o600);
+    const content = await fs.readFile(result.path!, 'utf8');
+    expect(content).toContain('VIBE_CHECK_API_KEY=secret-value');
+    expect(process.env.VIBE_CHECK_API_KEY).toBe('secret-value');
+    expect(closeSpy).toHaveBeenCalled();
+
+    await fs.rm(tempHome, { recursive: true, force: true });
+    homeSpy.mockRestore();
+  });
+});

--- a/tests/fixtures/claude/config.base.json
+++ b/tests/fixtures/claude/config.base.json
@@ -1,0 +1,4 @@
+{
+  "theme": "system",
+  "mcpServers": {}
+}

--- a/tests/fixtures/claude/config.with-managed-entry.json
+++ b/tests/fixtures/claude/config.with-managed-entry.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "vibe-check-mcp": {
+      "command": "npx",
+      "args": ["@pv-bhat/vibe-check-mcp", "start", "--stdio"],
+      "env": {},
+      "managedBy": "vibe-check-mcp-cli"
+    },
+    "other": {
+      "command": "bash",
+      "args": ["/usr/local/bin/run.sh"],
+      "env": {
+        "FOO": "BAR"
+      }
+    }
+  }
+}

--- a/tests/fixtures/claude/config.with-other-servers.json
+++ b/tests/fixtures/claude/config.with-other-servers.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "vibe-check-mcp": {
+      "command": "python",
+      "args": ["/opt/vibe-check.py"],
+      "env": {
+        "MCP_TRANSPORT": "stdio"
+      }
+    },
+    "another-server": {
+      "command": "node",
+      "args": ["/opt/another/index.js"],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a `vibe-check-mcp install --client claude` command that discovers Claude Desktop configs, merges a sentinel-managed entry, performs dry-run diffs, and writes backups atomically
- extend CLI env management to resolve `VIBE_CHECK_API_KEY`, prompt interactively, and write secure `.env` files for local or home scopes
- introduce diff utilities, fixtures, and vitest coverage for merge behavior, backup creation, dry-run output, and env prompting, plus update docs to describe the installer

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e8ffd7964c8332820165f7a362d7c9