### PR TITLE
feat: enforce Anthropic key prompts and document smithery CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,31 @@ npx @pv-bhat/vibe-check-mcp start --stdio
 
 # Install to a client
 npx @pv-bhat/vibe-check-mcp install --client claude
+npx @pv-bhat/vibe-check-mcp install --client claude-code
 npx @pv-bhat/vibe-check-mcp install --client cursor
 npx @pv-bhat/vibe-check-mcp install --client windsurf
 npx @pv-bhat/vibe-check-mcp install --client vscode --config ./.vscode/mcp.json
+
+# Discover supported clients
+npx @pv-bhat/vibe-check-mcp --list-clients
 
 # Doctor
 npx @pv-bhat/vibe-check-mcp doctor
 ```
 
 Requires Node **>=20**. These commands install straight from npm, build the CLI on demand, and work on any machine with `npx`.
+
+Claude Desktop and Claude Code rely on Anthropic – the installer enforces `ANTHROPIC_API_KEY` and will prompt to store it in
+`~/.vibe-check/.env` (or the project `.env` when you pass `--local`). Other clients can run on any supported provider key
+(`OPENAI_API_KEY`, `GEMINI_API_KEY`, or `OPENROUTER_API_KEY`); the CLI resolves secrets from your shell first, then project/home
+`.env` files.
+
+Prefer a hosted runtime? Smithery ships an official build of this server:
+
+```bash
+smithery add @PV-Bhat/vibe-check-mcp-server
+smithery run @PV-Bhat/vibe-check-mcp-server --client claude
+```
 
 ### By the numbers (as of 13 Oct 2025)
 - PulseMCP: ~32.3k total installs; ~12.8k this week; featured on “Most Popular (This Week)” front page
@@ -217,6 +233,8 @@ Ensure `NPM_TOKEN` is configured under **Repository Settings → Secrets and var
 ### Provider keys
 
 Set whichever API key matches your provider — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, or `OPENROUTER_API_KEY`. The installer requires at least one of these when running with `--non-interactive`.
+
+Claude-family installers (`--client claude` / `--client claude-code`) specifically validate `ANTHROPIC_API_KEY`. Provide it via your environment or `.env` before running in CI, otherwise the CLI will prompt interactively and persist the secret for you.
 
 Secrets default to `~/.vibe-check/.env` (created with `0600` permissions); pass `--local` to write to the current project's `.env`. Values are resolved in this order: shell environment → project `.env` → home config. The CLI never writes secrets to client config files – it references your environment instead.
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -2,11 +2,19 @@
 
 This document supplements the CLI installers documented in the [README](../README.md). Each section outlines discovery paths, schema nuances, and post-installation tips.
 
+> Tip: Run `npx @pv-bhat/vibe-check-mcp --list-clients` to see a quick summary of every supported integration.
+
+## API keys & secrets
+
+- Secrets resolve in this order: current shell → project `.env` → `~/.vibe-check/.env`. Interactive runs prompt once and persist new entries with `0600` permissions (use `--local` to target the project file).
+- Claude Desktop and Claude Code require `ANTHROPIC_API_KEY`; other clients accept whichever provider key you configure (`OPENAI_API_KEY`, `GEMINI_API_KEY`, or `OPENROUTER_API_KEY`). Non-interactive installs exit early if a required key is missing.
+
 ## Claude Desktop
 
 - **Config path**: `claude_desktop_config.json` (auto-detected per platform).
 - **Schema**: `mcpServers` map keyed by server ID.
 - **Default transport**: stdio (`npx -y @pv-bhat/vibe-check-mcp start --stdio`).
+- **API keys**: Requires `ANTHROPIC_API_KEY`.
 - **Restart**: Quit and relaunch Claude Desktop after installation.
 
 ```jsonc
@@ -23,6 +31,29 @@ This document supplements the CLI installers documented in the [README](../READM
 ```
 
 Docs: [Claude Desktop MCP](https://docs.anthropic.com/en/docs/claude-desktop/model-context-protocol)
+
+## Claude Code
+
+- **Config path**: `~/.config/Claude/claude_code_config.json` (auto-detected per platform).
+- **Schema**: Claude-style `mcpServers` map.
+- **Default transport**: stdio (`npx -y @pv-bhat/vibe-check-mcp start --stdio`).
+- **API keys**: Requires `ANTHROPIC_API_KEY`.
+- **Bootstrap**: Run `claude code login` or any Claude Code command once to scaffold the config file.
+
+```jsonc
+{
+  "mcpServers": {
+    "vibe-check-mcp": {
+      "command": "npx",
+      "args": ["-y", "@pv-bhat/vibe-check-mcp", "start", "--stdio"],
+      "env": {},
+      "managedBy": "vibe-check-mcp-cli"
+    }
+  }
+}
+```
+
+Docs: [Claude Code MCP integration](https://docs.anthropic.com/en/docs/agents/claude-code)
 
 ## Cursor
 

--- a/src/cli/clients/claude-code.ts
+++ b/src/cli/clients/claude-code.ts
@@ -1,0 +1,78 @@
+import { join } from 'node:path';
+import os from 'node:os';
+import {
+  ClientAdapter,
+  JsonRecord,
+  MergeOpts,
+  MergeResult,
+  expandHomePath,
+  mergeIntoMap,
+  pathExists,
+  readJsonFile,
+  writeJsonFileAtomic,
+} from './shared.js';
+
+const locateClaudeCodeConfig = async (customPath?: string): Promise<string | null> => {
+  if (customPath) {
+    return expandHomePath(customPath);
+  }
+
+  const home = os.homedir();
+  const candidates: string[] = [];
+
+  if (process.platform === 'darwin') {
+    candidates.push(join(home, 'Library', 'Application Support', 'Claude', 'claude_code_config.json'));
+  } else if (process.platform === 'win32') {
+    const appData = process.env.APPDATA;
+    if (appData) {
+      candidates.push(join(appData, 'Claude', 'claude_code_config.json'));
+    }
+  } else {
+    const xdgConfig = process.env.XDG_CONFIG_HOME;
+    if (xdgConfig) {
+      candidates.push(join(xdgConfig, 'Claude', 'claude_code_config.json'));
+    }
+    candidates.push(join(home, '.config', 'Claude', 'claude_code_config.json'));
+  }
+
+  for (const candidate of candidates) {
+    if (await pathExists(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+};
+
+const readClaudeCodeConfig = async (path: string, raw?: string): Promise<JsonRecord> => {
+  return readJsonFile(path, raw, 'Claude Code config');
+};
+
+const writeClaudeCodeConfigAtomic = async (path: string, data: JsonRecord): Promise<void> => {
+  await writeJsonFileAtomic(path, data);
+};
+
+const mergeClaudeCodeEntry = (config: JsonRecord, entry: JsonRecord, options: MergeOpts): MergeResult => {
+  return mergeIntoMap(config, entry, options, 'mcpServers');
+};
+
+const adapter: ClientAdapter = {
+  locate: locateClaudeCodeConfig,
+  read: readClaudeCodeConfig,
+  merge: mergeClaudeCodeEntry,
+  writeAtomic: writeClaudeCodeConfigAtomic,
+  describe() {
+    return {
+      name: 'Claude Code',
+      pathHint: '~/.config/Claude/claude_code_config.json',
+      summary: 'Anthropic\'s Claude Code CLI agent configuration.',
+      transports: ['stdio'],
+      defaultTransport: 'stdio',
+      requiredEnvKeys: ['ANTHROPIC_API_KEY'],
+      notes: 'Run `claude code login` once to scaffold the config file.',
+      docsUrl: 'https://docs.anthropic.com/en/docs/agents/claude-code',
+    };
+  },
+};
+
+export default adapter;

--- a/src/cli/clients/claude.ts
+++ b/src/cli/clients/claude.ts
@@ -73,7 +73,12 @@ const adapter: ClientAdapter = {
     return {
       name: 'Claude Desktop',
       pathHint: 'claude_desktop_config.json',
+      summary: 'Claude Desktop app integration for Windows, macOS, and Linux.',
+      transports: ['stdio'],
+      defaultTransport: 'stdio',
+      requiredEnvKeys: ['ANTHROPIC_API_KEY'],
       notes: 'Launch Claude Desktop once to generate the config file.',
+      docsUrl: 'https://docs.anthropic.com/en/docs/claude-desktop/model-context-protocol',
     };
   },
 };

--- a/src/cli/clients/cursor.ts
+++ b/src/cli/clients/cursor.ts
@@ -47,7 +47,11 @@ const adapter: ClientAdapter = {
     return {
       name: 'Cursor',
       pathHint: '~/.cursor/mcp.json',
+      summary: 'Cursor IDE with Claude-style MCP configuration.',
+      transports: ['stdio'],
+      defaultTransport: 'stdio',
       notes: 'Open Cursor Settings → MCP Servers if the file does not exist yet.',
+      docsUrl: 'https://docs.cursor.com/ai/model-context-protocol',
     };
   },
 };

--- a/src/cli/clients/shared.ts
+++ b/src/cli/clients/shared.ts
@@ -7,10 +7,12 @@ const { access, mkdir, readFile, rename, writeFile } = fsPromises;
 
 export type JsonRecord = Record<string, unknown>;
 
+export type TransportKind = 'stdio' | 'http';
+
 export type MergeOpts = {
   id: string;
   sentinel: string;
-  transport: 'stdio' | 'http';
+  transport: TransportKind;
   httpUrl?: string;
   dev?: {
     watch?: boolean;
@@ -24,12 +26,23 @@ export type MergeResult = {
   reason?: string;
 };
 
+export type ClientDescription = {
+  name: string;
+  pathHint: string;
+  summary?: string;
+  transports?: TransportKind[];
+  defaultTransport?: TransportKind;
+  requiredEnvKeys?: readonly string[];
+  notes?: string;
+  docsUrl?: string;
+};
+
 export interface ClientAdapter {
   locate(custom?: string): Promise<string | null>;
   read(path: string, raw?: string): Promise<JsonRecord>;
   merge(config: JsonRecord, entry: JsonRecord, options: MergeOpts): MergeResult;
   writeAtomic(path: string, data: JsonRecord): Promise<void>;
-  describe(): { name: string; pathHint: string; notes?: string };
+  describe(): ClientDescription;
 }
 
 export function isRecord(value: unknown): value is JsonRecord {

--- a/src/cli/clients/vscode.ts
+++ b/src/cli/clients/vscode.ts
@@ -67,7 +67,11 @@ const adapter: ClientAdapter = {
     return {
       name: 'Visual Studio Code',
       pathHint: '.vscode/mcp.json (workspace)',
+      summary: 'VS Code MCP configuration supporting stdio and HTTP transports.',
+      transports: ['stdio', 'http'],
+      defaultTransport: 'stdio',
       notes: 'Use the Command Palette → "MCP: Add Server" for profile installs.',
+      docsUrl: 'https://code.visualstudio.com/docs/copilot/mcp',
     };
   },
 };

--- a/src/cli/clients/windsurf.ts
+++ b/src/cli/clients/windsurf.ts
@@ -65,7 +65,11 @@ const adapter: ClientAdapter = {
     return {
       name: 'Windsurf',
       pathHint: '~/.codeium/windsurf/mcp_config.json',
+      summary: 'Codeium Windsurf IDE with stdio and HTTP MCP transports.',
+      transports: ['stdio', 'http'],
+      defaultTransport: 'stdio',
       notes: 'Newer builds use ~/.codeium/mcp_config.json. Create an empty file to opt-in.',
+      docsUrl: 'https://docs.codeium.com/windsurf/model-context-protocol',
     };
   },
 };

--- a/tests/claude-merge.test.ts
+++ b/tests/claude-merge.test.ts
@@ -88,7 +88,7 @@ describe('Claude MCP config merge', () => {
     const original = readFileSync(fixturePath, 'utf8');
     await fs.writeFile(configPath, original, 'utf8');
 
-    process.env.OPENAI_API_KEY = 'test-token';
+    process.env.ANTHROPIC_API_KEY = 'test-token';
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- require Claude installers to validate `ANTHROPIC_API_KEY`, surface API key requirements in the CLI helper, and include Smithery in the client listing
- extend the environment helper to prompt for required keys, add coverage for required-key flows, and update fixtures to use Anthropic tokens
- document how API keys are resolved, highlight the Claude-specific requirement, and add Smithery CLI quickstart instructions in the docs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f08d6a7044833290cfe94057c7041d