### PR TITLE
Fix CLI root command option handling

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -543,13 +543,15 @@ export function createCliProgram(): Command {
       }
     });
 
-  program.action((options: { listClients?: boolean }, command: Command) => {
+  program.action(() => {
+    const options = program.opts<{ listClients?: boolean }>();
+
     if (options.listClients) {
       showAvailableClients();
       return;
     }
 
-    command.help({ error: false });
+    program.help();
   });
 
   return program;


### PR DESCRIPTION
## Summary
- pull root CLI action options from Commander and invoke help when no flags are set
- return early to print the client list when --list-clients is provided

## Testing
- npm run build
- node build/cli/index.js
- node build/cli/index.js --list-clients

------
https://chatgpt.com/codex/tasks/task_e_68f0d35a425083329f6eb6302054c0ea