### PR TITLE
Document centralized API key guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,11 +232,7 @@ Ensure `NPM_TOKEN` is configured under **Repository Settings → Secrets and var
 
 ### Provider keys
 
-Set whichever API key matches your provider — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, or `OPENROUTER_API_KEY`. The installer requires at least one of these when running with `--non-interactive`.
-
-Claude-family installers (`--client claude` / `--client claude-code`) specifically validate `ANTHROPIC_API_KEY`. Provide it via your environment or `.env` before running in CI, otherwise the CLI will prompt interactively and persist the secret for you.
-
-Secrets default to `~/.vibe-check/.env` (created with `0600` permissions); pass `--local` to write to the current project's `.env`. Values are resolved in this order: shell environment → project `.env` → home config. The CLI never writes secrets to client config files – it references your environment instead.
+See [API Keys & Secret Management](./docs/api-keys.md) for supported providers, resolution order, storage locations, and security guidance. Claude installers (`--client claude` / `--client claude-code`) still require `ANTHROPIC_API_KEY`; configure it ahead of non-interactive runs to avoid prompts.
 
 ### Transport selection
 

--- a/docs/api-keys.md
+++ b/docs/api-keys.md
@@ -1,0 +1,35 @@
+# API Keys & Secret Management
+
+Vibe Check MCP works with multiple LLM providers. Use this guide to decide which keys you need, how they are discovered, where they are stored, and how to keep them secure.
+
+## Supported providers
+
+- **Anthropic** – `ANTHROPIC_API_KEY`
+- **Google Gemini** – `GEMINI_API_KEY`
+- **OpenAI** – `OPENAI_API_KEY`
+- **OpenRouter** – `OPENROUTER_API_KEY`
+
+Only one key is required to run the server, but you can set more than one to enable provider switching.
+
+## Secret resolution order
+
+When the CLI or server looks up a provider key it evaluates sources in the following order:
+
+1. Existing process environment variables.
+2. The current project's `.env` file (pass `--local` to write here).
+3. Your home directory config at `~/.vibe-check/.env`.
+
+The first match wins, so values in the shell take priority over project-level overrides, which in turn take priority over the persisted home config.
+
+## Storage locations
+
+- Interactive CLI runs create or update `~/.vibe-check/.env` with `0600` permissions so only your user can read it.
+- Supplying `--local` targets the project `.env`, letting you keep per-repository overrides under version control ignore rules.
+- Non-interactive runs expect keys to already be available in the environment or the relevant `.env` file; they will exit early if a required key is missing.
+
+## Security recommendations
+
+- Treat `.env` files as secrets: keep them out of version control and shared storage.
+- Use the minimal set of provider keys required for your workflow and rotate them periodically.
+- Prefer scoped or workspace-specific keys when your provider supports them.
+- Restrict file permissions to your user (the CLI enforces this for the home config) and avoid copying secrets into client config files.

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -4,10 +4,7 @@ This document supplements the CLI installers documented in the [README](../READM
 
 > Tip: Run `npx @pv-bhat/vibe-check-mcp --list-clients` to see a quick summary of every supported integration.
 
-## API keys & secrets
-
-- Secrets resolve in this order: current shell → project `.env` → `~/.vibe-check/.env`. Interactive runs prompt once and persist new entries with `0600` permissions (use `--local` to target the project file).
-- Claude Desktop and Claude Code require `ANTHROPIC_API_KEY`; other clients accept whichever provider key you configure (`OPENAI_API_KEY`, `GEMINI_API_KEY`, or `OPENROUTER_API_KEY`). Non-interactive installs exit early if a required key is missing.
+For supported providers, secret resolution, and storage guidance, read [API Keys & Secret Management](./api-keys.md). The notes below cover only client-specific requirements and edge cases.
 
 ## Claude Desktop
 


### PR DESCRIPTION
## Summary
- add docs/api-keys.md detailing provider coverage, secret resolution, storage, and security tips
- update README provider keys section to link to the new guide
- direct docs/clients.md readers to the central guidance while keeping client-specific requirements

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68f0d37ab2208332897ce0c5e282d0c8