### PR TITLE
Enforce provider key validation in ensureEnv prompts

### DIFF
--- a/src/cli/env.ts
+++ b/src/cli/env.ts
@@ -159,13 +159,9 @@ export async function ensureEnv(options: EnsureEnvOptions): Promise<EnsureEnvRes
     }
   }
 
-  if (!requiredKeys && resolved.size > 0) {
-    return { wrote: false };
-  }
-
   const missing = targetKeys.filter((key) => !resolved.has(key));
 
-  if (missing.length === 0) {
+  if (missing.length === 0 && invalidReasons.size === 0) {
     return { wrote: false };
   }
 
@@ -177,6 +173,9 @@ export async function ensureEnv(options: EnsureEnvOptions): Promise<EnsureEnvRes
       const invalidKeys = [...invalidReasons.keys()];
       return { wrote: false, missing: [...new Set([...invalidKeys, ...missing])] };
     }
+    if (!requiredKeys && resolved.size > 0) {
+      return { wrote: false };
+    }
     if (requiredKeys) {
       console.log(`Missing required API keys: ${requiredKeys.join(', ')}`);
       return { wrote: false, missing: [...missing] };
@@ -185,6 +184,10 @@ export async function ensureEnv(options: EnsureEnvOptions): Promise<EnsureEnvRes
     console.log(`No provider API keys detected. Set one of: ${targetKeys.join(', ')}`);
     console.log('Provide it via your shell or .env file, then re-run with --non-interactive.');
     return { wrote: false, missing: [...targetKeys] };
+  }
+
+  if (!requiredKeys && resolved.size > 0 && invalidReasons.size === 0) {
+    return { wrote: false };
   }
 
   const targetPath = options.local ? resolve(process.cwd(), '.env') : resolve(homeConfigDir(), '.env');

--- a/tests/claude-merge.test.ts
+++ b/tests/claude-merge.test.ts
@@ -88,7 +88,7 @@ describe('Claude MCP config merge', () => {
     const original = readFileSync(fixturePath, 'utf8');
     await fs.writeFile(configPath, original, 'utf8');
 
-    process.env.ANTHROPIC_API_KEY = 'test-token';
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-token';
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/tests/cli-install-dry-run.test.ts
+++ b/tests/cli-install-dry-run.test.ts
@@ -60,7 +60,7 @@ describe('cli install --dry-run', () => {
     const original = readFileSync(fixturePath, 'utf8');
     await fs.writeFile(configPath, original, 'utf8');
 
-    process.env.ANTHROPIC_API_KEY = 'dry-run-key';
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-dry-run-key';
 
     const logs: string[] = [];
     const logSpy = vi.spyOn(console, 'log').mockImplementation((message?: unknown, ...rest: unknown[]) => {

--- a/tests/cli-install-vscode-dry-run.test.ts
+++ b/tests/cli-install-vscode-dry-run.test.ts
@@ -15,7 +15,7 @@ describe('cli install vscode manual guidance', () => {
   });
 
   it('prints manual instructions and install link when config is missing', async () => {
-    process.env.OPENAI_API_KEY = 'manual-test';
+    process.env.OPENAI_API_KEY = 'sk-manual-test';
 
     const logs: string[] = [];
     const logSpy = vi.spyOn(console, 'log').mockImplementation((message?: unknown) => {

--- a/tests/cursor-merge.test.ts
+++ b/tests/cursor-merge.test.ts
@@ -80,7 +80,7 @@ describe('Cursor MCP config merge', () => {
     const original = readFileSync(join(FIXTURE_DIR, 'config.base.json'), 'utf8');
     await fs.writeFile(configPath, original, 'utf8');
 
-    process.env.OPENAI_API_KEY = 'cursor-key';
+    process.env.OPENAI_API_KEY = 'sk-cursor-key';
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/tests/llm.test.ts
+++ b/tests/llm.test.ts
@@ -40,7 +40,7 @@ describe('generateResponse', () => {
   });
 
   it('calls openrouter when configured', async () => {
-    process.env.OPENROUTER_API_KEY = 'key';
+    process.env.OPENROUTER_API_KEY = 'sk-or-key';
     mockedAxios.post = vi.fn(async () => ({ data: { choices: [{ message: { content: 'router reply' } }] } }));
     const res = await generateResponse({ goal: 'g', plan: 'p', modelOverride: { provider: 'openrouter', model: 'm1' } });
     expect(res.questions).toBe('router reply');

--- a/tests/vscode-merge.test.ts
+++ b/tests/vscode-merge.test.ts
@@ -83,7 +83,7 @@ describe('VS Code MCP config merge', () => {
     const original = readFileSync(join(FIXTURE_DIR, 'workspace.mcp.base.json'), 'utf8');
     await fs.writeFile(configPath, original, 'utf8');
 
-    process.env.OPENROUTER_API_KEY = 'vscode-key';
+    process.env.OPENROUTER_API_KEY = 'sk-or-vscode-key';
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/tests/windsurf-merge.test.ts
+++ b/tests/windsurf-merge.test.ts
@@ -99,7 +99,7 @@ describe('Windsurf MCP config merge', () => {
     const original = readFileSync(join(FIXTURE_DIR, 'config.base.json'), 'utf8');
     await fs.writeFile(configPath, original, 'utf8');
 
-    process.env.GEMINI_API_KEY = 'windsurf-key';
+    process.env.GEMINI_API_KEY = 'AI-windsurf-key';
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- add provider-specific validation rules to `ensureEnv` and include target file labels in prompts
- surface invalid provider keys immediately in both interactive and non-interactive flows
- update CLI environment tests to use valid key formats and cover retry/error scenarios

## Testing
- npx vitest run tests/env-ensure.test.ts
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f0d37c592c83329661b71c598fd1e5