### PR TITLE
chore: bump project version to v2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Introduce CLI scaffold and npx bin (no commands yet).
 
-## v2.7.0 - 2025-10-11
+## v2.7.1 - 2025-10-11
 
 - Added `install --client cursor|windsurf|vscode` adapters with managed-entry merges, atomic writes, and `.bak` rollbacks.
 - Preserved Windsurf `serverUrl` HTTP entries and emitted VS Code workspace snippets plus `vscode:mcp/install` links when configs are absent.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🧠 Vibe Check MCP v2.7.0
+# 🧠 Vibe Check MCP v2.7.1
 
 <p align="center"><b>KISS overzealous agents goodbye — stop over-engineering; ship the minimal viable path first.</b></p>
 
@@ -26,7 +26,7 @@
 
 <img width="500" height="300" alt="Gemini_Generated_Image_kvdvp4kvdvp4kvdv" src="https://github.com/user-attachments/assets/ff4d9efa-2142-436d-b1df-2a711a28c34e" />
 
-[![Version](https://img.shields.io/badge/version-2.7.0-purple)](https://github.com/PV-Bhat/vibe-check-mcp-server)
+[![Version](https://img.shields.io/badge/version-2.7.1-purple)](https://github.com/PV-Bhat/vibe-check-mcp-server)
 [![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/PV-Bhat/vibe-check-mcp-server)](https://archestra.ai/mcp-catalog/pv-bhat__vibe-check-mcp-server)
 [![smithery badge](https://smithery.ai/badge/@PV-Bhat/vibe-check-mcp-server)](https://smithery.ai/server/@PV-Bhat/vibe-check-mcp-server)
 [![Security 4.3★/5 on MSEEP](https://mseep.ai/badge.svg)](https://mseep.ai/app/a2954e62-a3f8-45b8-9a03-33add8b92599)
@@ -148,7 +148,7 @@ Large language models can confidently follow flawed plans. Without an external n
 | **History Continuity** | Summarizes prior advice when `sessionId` is supplied | context retention |
 | **Optional vibe_learn** | Log mistakes and fixes for future reflection | self-improvement |
 
-## What's New in v2.7.0
+## What's New in v2.7.1
 
 - `install --client` now supports Cursor, Windsurf, and Visual Studio Code with idempotent merges, atomic writes, and `.bak` rollbacks.
 - HTTP-aware installers preserve `serverUrl` entries for Windsurf and emit VS Code workspace snippets plus a `vscode:mcp/install` link when no config is provided.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pv-bhat/vibe-check-mcp",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pv-bhat/vibe-check-mcp",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
         "@google/generative-ai": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pv-bhat/vibe-check-mcp",
   "mcpName": "io.github.PV-Bhat/vibe-check-mcp-server",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Metacognitive AI agent oversight: adaptive CPI interrupts for alignment, reflection and safety",
   "main": "build/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump the package metadata to version 2.7.1
- refresh README and changelog references to advertise v2.7.1

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68f0f65371848332946b8c070f81a999