### PR TITLE
Add Anthropic provider integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Vibe Check MCP is a lightweight oversight layer for AI agents. It exposes two to
 - **vibe_check** – prompts you with clarifying questions to prevent tunnel vision.
 - **vibe_learn** – optional logging of mistakes and successes for later review.
 
-The server supports Gemini, OpenAI and OpenRouter LLMs. History is maintained across requests when a `sessionId` is provided.
+The server supports Gemini, OpenAI, Anthropic, and OpenRouter LLMs. History is maintained across requests when a `sessionId` is provided.
 
 ## Setup
 
@@ -18,7 +18,11 @@ The server supports Gemini, OpenAI and OpenRouter LLMs. History is maintained ac
    - `GEMINI_API_KEY`
    - `OPENAI_API_KEY`
    - `OPENROUTER_API_KEY`
-   - `DEFAULT_LLM_PROVIDER` (gemini | openai | openrouter)
+   - `ANTHROPIC_API_KEY` *(official Anthropic deployments)*
+   - `ANTHROPIC_AUTH_TOKEN` *(Anthropic-compatible proxies)*
+   - `ANTHROPIC_BASE_URL` *(optional; defaults to https://api.anthropic.com)*
+   - `ANTHROPIC_VERSION` *(optional; defaults to 2023-06-01)*
+   - `DEFAULT_LLM_PROVIDER` (gemini | openai | openrouter | anthropic)
    - `DEFAULT_MODEL` (e.g., gemini-2.5-pro)
 3. Start the server:
    ```bash

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Large language models can confidently follow flawed plans. Without an external n
 | Feature | Description | Benefits |
 |---------|-------------|----------|
 | **CPI Adaptive Interrupts** | Phase-aware prompts that challenge assumptions | alignment, robustness |
-| **Multi-provider LLM** | Gemini, OpenAI and OpenRouter support | flexibility |
+| **Multi-provider LLM** | Gemini, OpenAI, Anthropic, and OpenRouter support | flexibility |
 | **History Continuity** | Summarizes prior advice when `sessionId` is supplied | context retention |
 | **Optional vibe_learn** | Log mistakes and fixes for future reflection | self-improvement |
 
@@ -177,13 +177,39 @@ Create a `.env` file with the API keys you plan to use:
 ```bash
 # Gemini (default)
 GEMINI_API_KEY=your_gemini_api_key
-# Optional providers
+# Optional providers / Anthropic-compatible endpoints
 OPENAI_API_KEY=your_openai_api_key
 OPENROUTER_API_KEY=your_openrouter_api_key
+ANTHROPIC_API_KEY=your_anthropic_api_key
+ANTHROPIC_AUTH_TOKEN=your_proxy_bearer_token
+ANTHROPIC_BASE_URL=https://api.anthropic.com
+ANTHROPIC_VERSION=2023-06-01
 # Optional overrides
+# DEFAULT_LLM_PROVIDER accepts gemini | openai | openrouter | anthropic
 DEFAULT_LLM_PROVIDER=gemini
 DEFAULT_MODEL=gemini-2.5-pro
 ```
+
+#### Anthropic configuration examples
+
+Official Anthropic deployment:
+
+```bash
+DEFAULT_LLM_PROVIDER=anthropic
+ANTHROPIC_API_KEY=sk-ant-...
+DEFAULT_MODEL=claude-sonnet-4-20250514
+```
+
+Anthropic-compatible proxy (e.g., z.ai, Bedrock, or on-prem gateways):
+
+```bash
+DEFAULT_LLM_PROVIDER=anthropic
+ANTHROPIC_BASE_URL=https://<your-compatible-endpoint>/api/anthropic
+ANTHROPIC_AUTH_TOKEN=...
+DEFAULT_MODEL=claude-sonnet-4-20250514
+```
+
+Endpoints that advertise Anthropic compatibility only need a base URL + bearer token swap — no code changes required.
 Start the server:
 ```bash
 npm start

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -5,7 +5,7 @@ Vibe Check MCP is a lightweight oversight layer for AI agents. It exposes two to
 - **vibe_check** – prompts you with clarifying questions to prevent tunnel vision.
 - **vibe_learn** – optional logging of mistakes and successes for later review.
 
-The server supports Gemini, OpenAI and OpenRouter LLMs. History is maintained across requests when a `sessionId` is provided.
+The server supports Gemini, OpenAI, Anthropic, and OpenRouter LLMs. History is maintained across requests when a `sessionId` is provided.
 
 ## Setup
 
@@ -18,7 +18,11 @@ The server supports Gemini, OpenAI and OpenRouter LLMs. History is maintained ac
    - `GEMINI_API_KEY`
    - `OPENAI_API_KEY`
    - `OPENROUTER_API_KEY`
-   - `DEFAULT_LLM_PROVIDER` (gemini | openai | openrouter)
+   - `ANTHROPIC_API_KEY` *(official Anthropic deployments)*
+   - `ANTHROPIC_AUTH_TOKEN` *(Anthropic-compatible proxies)*
+   - `ANTHROPIC_BASE_URL` *(optional; defaults to https://api.anthropic.com)*
+   - `ANTHROPIC_VERSION` *(optional; defaults to 2023-06-01)*
+   - `DEFAULT_LLM_PROVIDER` (gemini | openai | openrouter | anthropic)
    - `DEFAULT_MODEL` (e.g., gemini-2.5-pro)
 3. Start the server:
    ```bash

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ if (USE_STDIO) {
 
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 
+export const SUPPORTED_LLM_PROVIDERS = ['gemini', 'openai', 'openrouter', 'anthropic'] as const;
+
 export interface LoggerLike {
   log: (...args: any[]) => void;
   error: (...args: any[]) => void;
@@ -88,7 +90,7 @@ export async function createMcpServer(): Promise<Server> {
             modelOverride: {
               type: 'object',
               properties: {
-                provider: { type: 'string', enum: ['gemini', 'openai', 'openrouter'] },
+                provider: { type: 'string', enum: [...SUPPORTED_LLM_PROVIDERS] },
                 model: { type: 'string' }
               },
               required: [],

--- a/src/utils/anthropic.ts
+++ b/src/utils/anthropic.ts
@@ -1,0 +1,48 @@
+export interface AnthropicConfig {
+  baseUrl: string;
+  apiKey?: string;
+  authToken?: string;
+  version: string;
+}
+
+export interface AnthropicHeaderInput {
+  apiKey?: string;
+  authToken?: string;
+  version: string;
+}
+
+export function resolveAnthropicConfig(): AnthropicConfig {
+  const trimmedBase = process.env.ANTHROPIC_BASE_URL?.replace(/\/+$/, '');
+  const baseUrl = trimmedBase && trimmedBase.length > 0 ? trimmedBase : 'https://api.anthropic.com';
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const authToken = process.env.ANTHROPIC_AUTH_TOKEN;
+  const version = process.env.ANTHROPIC_VERSION || '2023-06-01';
+
+  if (!apiKey && !authToken) {
+    throw new Error(
+      'Anthropic configuration error: set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN when provider "anthropic" is selected.'
+    );
+  }
+
+  return {
+    baseUrl,
+    apiKey,
+    authToken,
+    version,
+  };
+}
+
+export function buildAnthropicHeaders({ apiKey, authToken, version }: AnthropicHeaderInput): Record<string, string> {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    'anthropic-version': version,
+  };
+
+  if (apiKey) {
+    headers['x-api-key'] = apiKey;
+  } else if (authToken) {
+    headers.authorization = `Bearer ${authToken}`;
+  }
+
+  return headers;
+}

--- a/tests/llm-anthropic.test.ts
+++ b/tests/llm-anthropic.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SUPPORTED_LLM_PROVIDERS } from '../src/index.js';
+import { generateResponse } from '../src/utils/llm.js';
+
+const ORIGINAL_ENV = { ...process.env };
+const ORIGINAL_FETCH = global.fetch;
+
+describe('Anthropic provider', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+    delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.ANTHROPIC_VERSION;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_FETCH) {
+      global.fetch = ORIGINAL_FETCH;
+    } else {
+      // @ts-expect-error allow deleting fetch when absent
+      delete global.fetch;
+    }
+    vi.restoreAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('is exposed via the tool schema enum', () => {
+    expect(SUPPORTED_LLM_PROVIDERS).toContain('anthropic');
+  });
+
+  it('sends requests to the default endpoint when using an API key', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-xxx';
+
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          content: [{ type: 'text', text: 'anthropic reply' }],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await generateResponse({
+      goal: 'Goal',
+      plan: 'Plan',
+      modelOverride: { provider: 'anthropic', model: 'claude-3-haiku' },
+    });
+
+    expect(result.questions).toBe('anthropic reply');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.anthropic.com/v1/messages');
+    const headers = (options as RequestInit).headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('sk-ant-xxx');
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+    expect(headers).not.toHaveProperty('authorization');
+
+    const body = JSON.parse((options as RequestInit).body as string);
+    expect(body).toMatchObject({
+      model: 'claude-3-haiku',
+      max_tokens: 1024,
+    });
+    expect(body.messages).toEqual([
+      {
+        role: 'user',
+        content: expect.stringContaining('Goal: Goal'),
+      },
+    ]);
+  });
+
+  it('honors custom base URLs and bearer tokens', async () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://example.proxy/api/anthropic/';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'za_xxx';
+
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          content: [{ type: 'text', text: 'proxied reply' }],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await generateResponse({
+      goal: 'Goal',
+      plan: 'Plan',
+      modelOverride: { provider: 'anthropic', model: 'claude-3-sonnet' },
+    });
+
+    expect(result.questions).toBe('proxied reply');
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://example.proxy/api/anthropic/v1/messages');
+    const headers = (options as RequestInit).headers as Record<string, string>;
+    expect(headers.authorization).toBe('Bearer za_xxx');
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+    expect(headers).not.toHaveProperty('x-api-key');
+  });
+
+  it('prefers API keys when both credentials are present', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-xxx';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'za_xxx';
+
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({ content: [{ type: 'text', text: 'dual creds reply' }] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await generateResponse({
+      goal: 'Goal',
+      plan: 'Plan',
+      modelOverride: { provider: 'anthropic', model: 'claude-3-sonnet' },
+    });
+
+    const [, options] = fetchMock.mock.calls[0];
+    const headers = (options as RequestInit).headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('sk-ant-xxx');
+    expect(headers).not.toHaveProperty('authorization');
+  });
+
+  it('throws a configuration error when no credentials are provided', async () => {
+    const fetchSpy = vi.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    await expect(
+      generateResponse({ goal: 'Goal', plan: 'Plan', modelOverride: { provider: 'anthropic', model: 'claude-3' } }),
+    ).rejects.toThrow('Anthropic configuration error');
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('surfaces rate-limit errors with retry hints', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-xxx';
+
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({ error: { message: 'Too many requests' } }),
+        {
+          status: 429,
+          headers: {
+            'content-type': 'application/json',
+            'retry-after': '15',
+            'anthropic-request-id': 'req_123',
+          },
+        },
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      generateResponse({ goal: 'Goal', plan: 'Plan', modelOverride: { provider: 'anthropic', model: 'claude-3' } }),
+    ).rejects.toThrow(/rate limit exceeded.*Retry after 15 seconds/i);
+
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse((options as RequestInit).body as string);
+    expect(body.system).toContain('You are a meta-mentor');
+  });
+});


### PR DESCRIPTION
## Summary
- expose Anthropic as a supported LLM provider in the tool schema and documentation
- add configuration helpers and request plumbing to call Anthropic's Messages API
- cover Anthropic routing, headers, and error handling with new unit tests

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fa206ba9948332a465e0a7e4d036ec