### PR TITLE
feat: Automate GitHub releases and fix stdio transport initialization

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,53 @@
+name: Create GitHub Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          VERSION=${TAG#v}
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          
+          # Extract changelog section for this version
+          CHANGELOG_CONTENT=$(sed -n "/## v${VERSION} -/,/## v[0-9]/p" CHANGELOG.md | sed '$ d')
+          
+          # If no content found, use a default message
+          if [ -z "$CHANGELOG_CONTENT" ]; then
+            CHANGELOG_CONTENT="Release notes for version ${VERSION}. See [CHANGELOG.md](CHANGELOG.md) for details."
+          fi
+          
+          # Save to file to handle multiline content
+          echo "$CHANGELOG_CONTENT" > release-notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Vibe Check MCP ${{ steps.version.outputs.tag }}
+          body_path: release-notes.md
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,3 @@ temp/
 .npmrc
 .mcpregistry_github_token
 .mcpregistry_registry_token
-.aider*

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ temp/
 .npmrc
 .mcpregistry_github_token
 .mcpregistry_registry_token
+.aider*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Introduce CLI scaffold and npx bin (no commands yet).
 
-## v2.7.1 - 2025-10-11
+## v2.7.4 - 2025-10-11
 
 - Added `install --client cursor|windsurf|vscode` adapters with managed-entry merges, atomic writes, and `.bak` rollbacks.
 - Preserved Windsurf `serverUrl` HTTP entries and emitted VS Code workspace snippets plus `vscode:mcp/install` links when configs are absent.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use VibeCheck MCP in your research, cite this repository."
 title: "VibeCheck MCP"
-version: "2.7.3"
+version: "2.7.4"
 authors:
   - family-names: Bhat
     given-names: Pruthvi

--- a/docs/release-workflows.md
+++ b/docs/release-workflows.md
@@ -3,7 +3,7 @@
 ## Source of truth
 
 - `version.json` stores the canonical semantic version for the project. Update this file first when preparing a release.
-- `scripts/sync-version.mjs` reads `version.json` and synchronizes `package.json`, `package-lock.json`, `README.md`, and the primary `CHANGELOG.md` headers.
+- `scripts/sync-version.mjs` reads `version.json` and synchronizes `package.json`, `package-lock.json`, `README.md`, `CITATION.cff`, and the primary `CHANGELOG.md` headers.
 
 ## Syncing metadata
 
@@ -24,10 +24,18 @@
 - `npm publish` should only be executed after the sync step so the registry receives the correct version number.
 - Use `npm pack` or `npm publish --dry-run` to verify the release contents locally when iterating on the workflow.
 
+## GitHub Release Automation
+
+- When a git tag matching `v*.*.*` is pushed, the `create-release.yml` workflow automatically creates a GitHub release.
+- The release notes are extracted from `CHANGELOG.md` for that version.
+- The `release.yml` workflow automatically publishes to npm.
+
 ## Checklist
 
 - [ ] Update `version.json`
 - [ ] `npm run sync-version`
 - [ ] Update changelog entries (`CHANGELOG.md`, optional `docs/changelog.md`)
 - [ ] `npm test` (or relevant verification)
-- [ ] `npm publish` (after confirming `npm run prepublishOnly` completes successfully)
+- [ ] Commit all changes
+- [ ] Create and push a git tag (e.g., `git tag v2.x.x && git push origin v2.x.x`)
+- [ ] GitHub Actions will automatically create the release and publish to npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pv-bhat/vibe-check-mcp",
-  "version": "2.7.1",
+  "version": "2.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pv-bhat/vibe-check-mcp",
-      "version": "2.7.1",
+      "version": "2.7.4",
       "license": "MIT",
       "dependencies": {
         "@google/generative-ai": "^0.17.1",

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -72,6 +72,10 @@ const main = async () => {
     { pattern: /## v\d+\.\d+\.\d+ -/, value: `## v${newVersion} -` }
   ]);
 
+  await replaceInFile('CITATION.cff', [
+    { pattern: /version: "\d+\.\d+\.\d+"/, value: `version: "${newVersion}"` }
+  ]);
+
   console.log(`Synchronized project files to version ${newVersion}`);
 };
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -625,8 +625,9 @@ async function createBackup(path: string, contents: string): Promise<string> {
   return backupPath;
 }
 
-const executedFile = process.argv[1] ? pathToFileURL(process.argv[1]).href : undefined;
-if (executedFile === import.meta.url) {
+const executedFile = process.argv[1] ? realpathSync(fileURLToPath(pathToFileURL(process.argv[1]))) : undefined;
+const thisFile = realpathSync(fileURLToPath(import.meta.url));
+if (executedFile === thisFile) {
   createCliProgram()
     .parseAsync(process.argv)
     .catch((error: unknown) => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFileSync, promises as fsPromises } from 'node:fs';
+import { readFileSync, promises as fsPromises, realpathSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { Command, Option } from 'commander';
@@ -55,7 +55,8 @@ type InstallOptions = {
   devDebug?: string;
 };
 
-const cliDir = dirname(fileURLToPath(import.meta.url));
+const realPath = realpathSync(fileURLToPath(import.meta.url));
+const cliDir = dirname(realPath);
 const projectRoot = resolve(cliDir, '..', '..');
 const entrypoint = resolve(projectRoot, 'build', 'index.js');
 const packageJsonPath = resolve(projectRoot, 'package.json');

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,11 +24,7 @@ import { applyJsonRpcCompatibility, wrapTransportForCompatibility } from './util
 import { createRequestScopedTransport, RequestScopeStore } from './utils/httpTransportWrapper.js';
 
 const IS_DISCOVERY = process.env.MCP_DISCOVERY_MODE === '1';
-const USE_STDIO = process.env.MCP_TRANSPORT === 'stdio';
-
-if (USE_STDIO) {
-  console.log = (...args) => console.error(...args);
-}
+const useStdio = () => process.env.MCP_TRANSPORT === 'stdio';
 
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 
@@ -436,11 +432,14 @@ export async function startHttpServer(options: HttpServerOptions = {}): Promise<
 }
 
 export async function main(options: MainOptions = {}) {
+  if (useStdio()) {
+    console.log = (...args) => console.error(...args);
+  }
   const createServerFn = options.createServer ?? createMcpServer;
   const startHttpFn = options.startHttp ?? startHttpServer;
   const server = await createServerFn();
 
-  if (USE_STDIO) {
+  if (useStdio()) {
     const transport = wrapTransportForCompatibility(new StdioServerTransport());
     await server.connect(transport);
     console.error('[MCP] stdio transport connected');

--- a/tests/jsonrpc-compat.test.ts
+++ b/tests/jsonrpc-compat.test.ts
@@ -439,7 +439,9 @@ describe('JSON-RPC compatibility shim', () => {
 
     // Mock StdioServerTransport to prevent it from reading from process.stdin, which would hang the test.
     vi.doMock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
-      StdioServerTransport: class MockStdioTransport {},
+      StdioServerTransport: class MockStdioTransport {
+        start = vi.fn(async () => {});
+      },
     }));
     await stubState(); // main() calls createMcpServer which calls loadHistory()
 

--- a/tests/jsonrpc-compat.test.ts
+++ b/tests/jsonrpc-compat.test.ts
@@ -437,14 +437,24 @@ describe('JSON-RPC compatibility shim', () => {
     const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     let errorSpy: ReturnType<typeof vi.spyOn> | null = null;
 
+    // Mock StdioServerTransport to prevent it from reading from process.stdin, which would hang the test.
+    vi.doMock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+      StdioServerTransport: class MockStdioTransport {},
+    }));
+    await stubState(); // main() calls createMcpServer which calls loadHistory()
+
     try {
-      await import('../src/index.js');
+      const { main } = await import('../src/index.js');
+      // The console redirection happens inside main().
+      await main();
+
       errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       console.log('shim-log');
       expect(errorSpy).toHaveBeenCalledWith('shim-log');
       expect(stdoutSpy).not.toHaveBeenCalled();
     } finally {
       errorSpy?.mockRestore();
+      stdoutSpy.mockRestore();
       console.log = originalLog;
       console.error = originalError;
     }


### PR DESCRIPTION
## Overview

This PR introduces several improvements to the Vibe Check MCP project, focusing on fixing critical runtime issues, enhancing release automation, and improving CLI reliability.

## Changes Summary

### 🐛 Bug Fixes

#### 1. **Fix stdio transport initialization error (MCP error -32000)**
- **Problem**: When starting the server via CLI with `--stdio` flag or through npx, the server would fail with `McpError: MCP error -32000: Connection closed`
- **Root Cause**: The `USE_STDIO` constant was evaluated at module load time, before the CLI set the environment variable
- **Solution**: Changed `USE_STDIO` to `useStdio()` function for runtime evaluation
- **Files**: `src/index.ts`, `tests/jsonrpc-compat.test.ts`

**Before:**
```typescript
const USE_STDIO = process.env.MCP_TRANSPORT === 'stdio';
```

**After:**
```typescript
const useStdio = () => process.env.MCP_TRANSPORT === 'stdio';

export async function main(options: MainOptions = {}) {
  if (useStdio()) {
    console.log = (...args) => console.error(...args);
  }
  // ...
  if (useStdio()) {
    const transport = wrapTransportForCompatibility(new StdioServerTransport());
    await server.connect(transport);
  }
}
```

#### 2. **Fix CLI execution guard for symlinked installations**
- **Problem**: CLI wouldn't execute properly when installed via npm link or symlinked globally
- **Solution**: Resolve symlinks using `realpathSync()` before comparing paths
- **Files**: `src/cli/index.ts`

**Changes:**
```typescript
// Resolve symlinks for proper path comparison
const realPath = realpathSync(fileURLToPath(import.meta.url));
const cliDir = dirname(realPath);

// Normalize execution guard
const executedFile = process.argv[1] ? realpathSync(fileURLToPath(pathToFileURL(process.argv[1]))) : undefined;
const thisFile = realpathSync(fileURLToPath(import.meta.url));
if (executedFile === thisFile) {
  // Execute CLI
}
```

### ✨ Features

#### 3. **Automated GitHub Release Creation**
- **What**: New GitHub Actions workflow that automatically creates GitHub releases when version tags are pushed
- **How**: Extracts release notes from CHANGELOG.md and creates releases with proper formatting
- **Files**: `.github/workflows/create-release.yml`

**Workflow Features:**
- Triggers on `v*` tags (e.g., `v2.7.4`)
- Extracts version-specific changelog sections
- Creates releases with title format: "Vibe Check MCP v{version}"
- Automatically handles release notes from CHANGELOG.md

#### 4. **Version Sync Improvements**
- **What**: Enhanced `sync-version.mjs` to automatically update `CITATION.cff`
- **Why**: Ensures consistent versioning across all project files including academic citation files
- **Files**: `scripts/sync-version.mjs`, `CITATION.cff`

**Added:**
```javascript
await replaceInFile('CITATION.cff', [
  { pattern: /version: "\d+\.\d+\.\d+"/, value: `version: "${newVersion}"` }
]);
```

### 📚 Documentation

#### 5. **Updated Release Workflow Documentation**
- Enhanced `docs/release-workflows.md` with details about the new GitHub automation
- Clarified the relationship between npm publishing and GitHub releases
- **Files**: `docs/release-workflows.md`

## Testing

### Manual Testing
✅ **Stdio transport verified:**
```bash
echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | node build/cli/index.js start --stdio
# Returns proper JSON-RPC response with tools list
```

✅ **CLI dry-run confirms correct environment:**
```bash
node build/cli/index.js start --stdio --dry-run
# Output shows: MCP_TRANSPORT=stdio
```

✅ **Symlinked installation works:**
```bash
npm link
vibe-check-mcp start --stdio --dry-run
# CLI executes correctly
```

### Automated Testing
✅ All existing tests pass: **98 passed** (2 pre-existing unrelated failures)  
✅ Updated test: "routes logs to stderr when MCP_TRANSPORT=stdio" now passes with proper mocking  
✅ Test suite: `tests/jsonrpc-compat.test.ts` - 13/13 passing

## Alignment with Vibe Check Purpose

These changes directly address real-world integration problems that users face when setting up Vibe Check with their MCP clients:

1. **Stdio transport fix** ensures proper metacognitive oversight for AI agents using the recommended npx configuration
2. **CLI improvements** make the tool more reliable across different installation methods (global, npx, symlinked)
3. **Release automation** streamlines the release process, making it easier to maintain and distribute updates to the community

## Breaking Changes

None. All changes are backward compatible.

## Related Configuration

This PR enables users to successfully use the recommended configuration:
```json
{
  "mcpServers": {
    "vibe-check-mcp": {
      "command": "npx",
      "args": ["-y", "@pv-bhat/vibe-check-mcp", "start", "--stdio"]
    }
  }
}
```

Or global installation:
```bash
npm install -g @pv-bhat/vibe-check-mcp
```

```json
{
  "mcpServers": {
    "vibe-check-mcp": {
      "command": "vibe-check-mcp",
      "args": ["start", "--stdio"]
    }
  }
}
```

## Files Changed

- `.github/workflows/create-release.yml` - New GitHub Actions workflow for automated releases
- `CHANGELOG.md` - Version updates
- `CITATION.cff` - Version sync (2.7.3 → 2.7.4)
- `docs/release-workflows.md` - Updated with automation details
- `package-lock.json` - Dependency updates
- `scripts/sync-version.mjs` - Enhanced to update CITATION.cff
- `src/cli/index.ts` - Fixed symlink resolution for CLI execution guard
- `src/index.ts` - Fixed stdio transport runtime evaluation
- `tests/jsonrpc-compat.test.ts` - Updated test with proper mocking

## Commits

1. `da3696a` - fix: Resolve symlinked CLI path for correct project root
2. `23cff1d` - fix: Normalize paths for CLI execution guard
3. `e1ad6b3` - docs: Update release docs to reflect automated GitHub/npm process
4. `e704e8c` - feat(automation): add GitHub release automation and version sync improvements
5. `54e8cbb` - fix: Defer stdio transport env var evaluation
6. `69f0f12` - test: Fix stdio log redirection test with main() call and transport mock
7. `5fb576f` - fix: Add start method to MockStdioTransport in stdio test